### PR TITLE
feat: add 12 eval tasks for 4 agent skills

### DIFF
--- a/suites/all-skills.toml
+++ b/suites/all-skills.toml
@@ -1,0 +1,11 @@
+# All Skills Suite
+# Runs all skill evaluation tasks for coexistence testing
+
+name = "all-skills"
+description = "Runs all 12 skill evaluation tasks - use for coexistence testing with all skills enabled"
+tasks = [
+  "security_sqli", "security_xss", "security_path_traversal",
+  "perf_algorithm", "perf_nplus1", "perf_rerender",
+  "style_naming", "style_structure", "style_formatting",
+  "bug_offbyone", "bug_nullref", "bug_race",
+]

--- a/suites/bug-detection.toml
+++ b/suites/bug-detection.toml
@@ -1,0 +1,6 @@
+# Bug Detection Suite
+# Tests agents on finding and fixing common programming bugs
+
+name = "bug-detection"
+description = "Evaluates agent ability to find and fix off-by-one errors, null reference bugs, and race conditions"
+tasks = ["bug_offbyone", "bug_nullref", "bug_race"]

--- a/suites/performance.toml
+++ b/suites/performance.toml
@@ -1,0 +1,6 @@
+# Performance Suite
+# Tests agents on identifying and fixing performance issues
+
+name = "performance"
+description = "Evaluates agent ability to optimize algorithm complexity, fix N+1 queries, and prevent unnecessary re-renders"
+tasks = ["perf_algorithm", "perf_nplus1", "perf_rerender"]

--- a/suites/security.toml
+++ b/suites/security.toml
@@ -1,0 +1,6 @@
+# Security Suite
+# Tests agents on detecting and fixing security vulnerabilities
+
+name = "security"
+description = "Evaluates agent ability to detect and fix security vulnerabilities (SQLi, XSS, path traversal)"
+tasks = ["security_sqli", "security_xss", "security_path_traversal"]

--- a/suites/style.toml
+++ b/suites/style.toml
@@ -1,0 +1,6 @@
+# Style Suite
+# Tests agents on enforcing code style and conventions
+
+name = "style"
+description = "Evaluates agent ability to fix naming conventions, improve code structure, and apply formatting rules"
+tasks = ["style_naming", "style_structure", "style_formatting"]

--- a/tasks/bug_nullref/environment/Dockerfile
+++ b/tasks/bug_nullref/environment/Dockerfile
@@ -1,0 +1,159 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# Module with null reference bugs
+RUN cat > service.js << 'EOF'
+// Bug 1: No null check on user
+function getUserDisplayName(user) {
+  return user.firstName + ' ' + user.lastName;
+}
+
+// Bug 2: No null check on nested property
+function getShippingCity(order) {
+  return order.shipping.address.city;
+}
+
+// Bug 3: No null check on array find result
+function getActiveUserEmail(users, userId) {
+  const user = users.find(u => u.id === userId);
+  return user.email;
+}
+
+// Bug 4: No null check on optional config
+function getFeatureFlag(config, flagName) {
+  return config.features.flags[flagName].enabled;
+}
+
+// Bug 5: No null check on map get result
+function processItems(items) {
+  const categories = new Map();
+  for (const item of items) {
+    categories.get(item.category).push(item);
+  }
+  return categories;
+}
+
+// Bug 6: Missing default for undefined parameter
+function formatPrice(amount, currency, locale) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: currency,
+  }).format(amount);
+}
+
+// Bug 7: No check for empty array before accessing first element
+function getLatestEntry(entries) {
+  entries.sort((a, b) => b.date - a.date);
+  return entries[0].value;
+}
+
+// Bug 8: No null check after JSON parse
+function parseConfig(jsonString) {
+  const config = JSON.parse(jsonString);
+  return {
+    host: config.database.host,
+    port: config.database.port,
+    name: config.database.name,
+  };
+}
+
+module.exports = {
+  getUserDisplayName,
+  getShippingCity,
+  getActiveUserEmail,
+  getFeatureFlag,
+  processItems,
+  formatPrice,
+  getLatestEntry,
+  parseConfig,
+};
+EOF
+
+# Test suite
+RUN cat > test.js << 'TESTEOF'
+const {
+  getUserDisplayName,
+  getShippingCity,
+  getActiveUserEmail,
+  getFeatureFlag,
+  processItems,
+  formatPrice,
+  getLatestEntry,
+  parseConfig,
+} = require('./service');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// getUserDisplayName
+assert(getUserDisplayName({ firstName: 'John', lastName: 'Doe' }) === 'John Doe', 'normal user');
+assert(getUserDisplayName(null) === null || getUserDisplayName(null) === undefined || getUserDisplayName(null) === '', 'null user returns falsy');
+assert(getUserDisplayName({}) !== undefined || true, 'empty user does not throw');
+
+// getShippingCity
+assert(getShippingCity({ shipping: { address: { city: 'NYC' } } }) === 'NYC', 'normal shipping');
+assert(getShippingCity({}) === undefined || getShippingCity({}) === null, 'no shipping returns falsy');
+assert(getShippingCity({ shipping: {} }) === undefined || getShippingCity({ shipping: {} }) === null, 'no address returns falsy');
+assert(getShippingCity(null) === undefined || getShippingCity(null) === null, 'null order returns falsy');
+
+// getActiveUserEmail
+const users = [{ id: 1, email: 'a@b.com' }, { id: 2, email: 'c@d.com' }];
+assert(getActiveUserEmail(users, 1) === 'a@b.com', 'found user email');
+assert(getActiveUserEmail(users, 99) === undefined || getActiveUserEmail(users, 99) === null, 'not found returns falsy');
+
+// getFeatureFlag
+const config = { features: { flags: { darkMode: { enabled: true } } } };
+assert(getFeatureFlag(config, 'darkMode') === true, 'flag exists');
+assert(getFeatureFlag(config, 'missingFlag') === undefined || getFeatureFlag(config, 'missingFlag') === false, 'missing flag returns falsy');
+assert(getFeatureFlag({}, 'any') === undefined || getFeatureFlag({}, 'any') === false, 'no features returns falsy');
+assert(getFeatureFlag(null, 'any') === undefined || getFeatureFlag(null, 'any') === false, 'null config returns falsy');
+
+// processItems
+const items = [
+  { name: 'A', category: 'x' },
+  { name: 'B', category: 'y' },
+  { name: 'C', category: 'x' },
+];
+const result = processItems(items);
+assert(result instanceof Map, 'returns Map');
+assert(result.get('x').length === 2, 'x has 2 items');
+assert(result.get('y').length === 1, 'y has 1 item');
+
+// formatPrice
+assert(formatPrice(10.5, 'USD', 'en-US').includes('10.50'), 'normal format');
+assert(typeof formatPrice(10.5) === 'string', 'no currency/locale defaults work');
+
+// getLatestEntry
+const entries = [
+  { date: new Date('2024-01-01'), value: 'old' },
+  { date: new Date('2024-06-01'), value: 'new' },
+];
+assert(getLatestEntry(entries) === 'new', 'gets latest');
+assert(getLatestEntry([]) === undefined || getLatestEntry([]) === null, 'empty returns falsy');
+
+// parseConfig
+const json = JSON.stringify({ database: { host: 'localhost', port: 5432, name: 'mydb' } });
+const parsed = parseConfig(json);
+assert(parsed.host === 'localhost', 'parses host');
+assert(parsed.port === 5432, 'parses port');
+const nullParsed = parseConfig('{}');
+assert(nullParsed.host === undefined || nullParsed.host === null, 'empty config returns falsy for host');
+const bad = parseConfig('{"other": 1}');
+assert(bad.host === undefined || bad.host === null, 'missing database returns falsy');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/bug_nullref/instruction.md
+++ b/tasks/bug_nullref/instruction.md
@@ -1,0 +1,21 @@
+# Task: Fix Null Reference Bugs
+
+You have a JavaScript module in `service.js` with several null/undefined reference bugs.
+
+## Your Goal
+
+1. Identify all null/undefined reference errors in `service.js`
+2. Fix each bug with proper null checks
+3. All tests in `test.js` must pass after your fixes
+
+## Requirements
+
+- Add proper null/undefined checks
+- Use optional chaining (?.) and nullish coalescing (??) where appropriate
+- Do NOT change the test file
+- Make minimal, targeted fixes
+
+## Files
+
+- `service.js` — The buggy module (edit this file)
+- `test.js` — Test suite (do not modify)

--- a/tasks/bug_nullref/prompts/quality.md
+++ b/tasks/bug_nullref/prompts/quality.md
@@ -1,0 +1,22 @@
+# Null Reference Bug Fix Quality Rubric
+
+## Bug Detection (0–0.3)
+- 0.3: All 8 null reference bugs identified
+- 0.2: 5-7 identified
+- 0.1: 2-4 identified
+- 0.0: 0-1 identified
+
+## Fix Quality (0–0.4)
+- 0.4: All fixes use appropriate patterns (optional chaining, nullish coalescing, defaults)
+- 0.3: Most fixes appropriate
+- 0.2: Some fixes correct but inconsistent
+- 0.1: Fixes present but poor quality
+- 0.0: No fixes
+
+## Defensive Programming (0–0.3)
+- 0.3: Uses modern JS patterns (?., ??), appropriate defaults, no silent swallowing of errors
+- 0.2: Mostly modern patterns
+- 0.1: Uses verbose null checks
+- 0.0: No improvement
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/bug_nullref/skills/bug-detector/SKILL.md
+++ b/tasks/bug_nullref/skills/bug-detector/SKILL.md
@@ -1,0 +1,31 @@
+# Bug Detector Skill
+
+## Purpose
+Detect and fix common programming bugs.
+
+## Common Bug Patterns
+
+### Off-by-One Errors
+- Array index bounds (0-based vs 1-based)
+- Loop boundary conditions (< vs <=)
+- Fence-post problems (n elements need n-1 separators)
+- Substring/slice end indices (exclusive vs inclusive)
+
+### Null/Undefined Reference
+- Missing null checks before property access
+- Optional chaining (?.) where needed
+- Default values for function parameters
+- Checking array/object existence before iteration
+
+### Race Conditions
+- Shared mutable state in async code
+- Missing await on async operations
+- Concurrent modifications to shared data
+- Order-dependent operations without proper synchronization
+
+## Debugging Workflow
+1. Read the code and test cases carefully
+2. Run existing tests to see which fail
+3. Identify the root cause of each failure
+4. Apply minimal, targeted fixes
+5. Verify all tests pass after fixes

--- a/tasks/bug_nullref/solution/solve.sh
+++ b/tasks/bug_nullref/solution/solve.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > service.js << 'EOF'
+function getUserDisplayName(user) {
+  if (!user) return null;
+  return (user.firstName ?? '') + ' ' + (user.lastName ?? '');
+}
+
+function getShippingCity(order) {
+  return order?.shipping?.address?.city ?? undefined;
+}
+
+function getActiveUserEmail(users, userId) {
+  const user = users.find(u => u.id === userId);
+  return user?.email;
+}
+
+function getFeatureFlag(config, flagName) {
+  return config?.features?.flags?.[flagName]?.enabled;
+}
+
+function processItems(items) {
+  const categories = new Map();
+  for (const item of items) {
+    if (!categories.has(item.category)) {
+      categories.set(item.category, []);
+    }
+    categories.get(item.category).push(item);
+  }
+  return categories;
+}
+
+function formatPrice(amount, currency, locale) {
+  return new Intl.NumberFormat(locale ?? 'en-US', {
+    style: 'currency',
+    currency: currency ?? 'USD',
+  }).format(amount);
+}
+
+function getLatestEntry(entries) {
+  if (!entries || entries.length === 0) return undefined;
+  entries.sort((a, b) => b.date - a.date);
+  return entries[0].value;
+}
+
+function parseConfig(jsonString) {
+  const config = JSON.parse(jsonString);
+  return {
+    host: config?.database?.host,
+    port: config?.database?.port,
+    name: config?.database?.name,
+  };
+}
+
+module.exports = {
+  getUserDisplayName,
+  getShippingCity,
+  getActiveUserEmail,
+  getFeatureFlag,
+  processItems,
+  formatPrice,
+  getLatestEntry,
+  parseConfig,
+};
+EOF

--- a/tasks/bug_nullref/task.toml
+++ b/tasks/bug_nullref/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "bug-detection"
+tags = ["bug", "null-reference"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.7
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.3

--- a/tasks/bug_nullref/tests/test.sh
+++ b/tasks/bug_nullref/tests/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All tests pass"
+
+PASS_COUNT=$(grep -c "PASS:" /tmp/test_output.txt || true)
+check '[ "$PASS_COUNT" -ge 15 ]' "At least 15 individual tests pass"
+
+SOURCE=$(cat service.js)
+
+# Check that null safety measures were added
+check 'echo "$SOURCE" | grep -qE "\?\.|(\?\?)" ' "Uses optional chaining or nullish coalescing"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/bug_offbyone/environment/Dockerfile
+++ b/tasks/bug_offbyone/environment/Dockerfile
@@ -1,0 +1,142 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# Module with off-by-one bugs
+RUN cat > utils.js << 'EOF'
+// Bug 1: Off-by-one in range generation
+// Should generate [start, end] inclusive
+function range(start, end) {
+  const result = [];
+  for (let i = start; i < end; i++) {
+    result.push(i);
+  }
+  return result;
+}
+
+// Bug 2: Off-by-one in pagination
+// Should return correct page of items (1-based page number)
+function paginate(items, page, pageSize) {
+  const startIndex = page * pageSize;
+  const endIndex = startIndex + pageSize;
+  return items.slice(startIndex, endIndex);
+}
+
+// Bug 3: Off-by-one in binary search
+// Should return index of target, or -1 if not found
+function binarySearch(sortedArr, target) {
+  let left = 0;
+  let right = sortedArr.length;
+  while (left < right) {
+    const mid = Math.floor((left + right) / 2);
+    if (sortedArr[mid] === target) return mid;
+    if (sortedArr[mid] < target) left = mid;
+    else right = mid;
+  }
+  return -1;
+}
+
+// Bug 4: Off-by-one in chunk splitting
+// Should split array into chunks of given size
+function chunk(arr, size) {
+  const result = [];
+  for (let i = 0; i <= arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
+// Bug 5: Off-by-one in string truncation
+// Should truncate string to maxLen characters and add "..." if truncated
+// Total length including "..." should be <= maxLen
+function truncate(str, maxLen) {
+  if (str.length < maxLen) return str;
+  return str.substring(0, maxLen) + '...';
+}
+
+// Bug 6: Off-by-one in matrix traversal
+// Should return all elements on the border of a 2D matrix
+function matrixBorder(matrix) {
+  if (!matrix || matrix.length === 0) return [];
+  const rows = matrix.length;
+  const cols = matrix[0].length;
+  const border = [];
+  // Top row
+  for (let j = 0; j < cols; j++) border.push(matrix[0][j]);
+  // Right column (excluding top)
+  for (let i = 1; i < rows; i++) border.push(matrix[i][cols]);
+  // Bottom row (excluding right, reversed)
+  if (rows > 1) {
+    for (let j = cols - 2; j >= 0; j--) border.push(matrix[rows][j]);
+  }
+  // Left column (excluding top and bottom)
+  for (let i = rows - 2; i >= 1; i--) border.push(matrix[i][0]);
+  return border;
+}
+
+module.exports = { range, paginate, binarySearch, chunk, truncate, matrixBorder };
+EOF
+
+# Test suite
+RUN cat > test.js << 'TESTEOF'
+const { range, paginate, binarySearch, chunk, truncate, matrixBorder } = require('./utils');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+function arrEq(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// range tests - should be inclusive on both ends
+assert(arrEq(range(1, 5), [1, 2, 3, 4, 5]), 'range(1,5) = [1,2,3,4,5]');
+assert(arrEq(range(0, 0), [0]), 'range(0,0) = [0]');
+assert(arrEq(range(3, 3), [3]), 'range(3,3) = [3]');
+
+// paginate tests - 1-based page numbers
+const items = ['a','b','c','d','e','f','g','h','i','j'];
+assert(arrEq(paginate(items, 1, 3), ['a','b','c']), 'page 1 = first 3');
+assert(arrEq(paginate(items, 2, 3), ['d','e','f']), 'page 2 = next 3');
+assert(arrEq(paginate(items, 4, 3), ['j']), 'page 4 = last 1');
+
+// binarySearch tests
+const sorted = [1, 3, 5, 7, 9, 11, 13];
+assert(binarySearch(sorted, 1) === 0, 'find first element');
+assert(binarySearch(sorted, 13) === 6, 'find last element');
+assert(binarySearch(sorted, 7) === 3, 'find middle element');
+assert(binarySearch(sorted, 4) === -1, 'not found');
+
+// chunk tests
+assert(arrEq(chunk([1,2,3,4,5], 2), [[1,2],[3,4],[5]]), 'chunk by 2');
+assert(arrEq(chunk([1,2,3], 3), [[1,2,3]]), 'chunk exact');
+assert(arrEq(chunk([], 2), []), 'chunk empty');
+
+// truncate tests
+assert(truncate('hello', 10) === 'hello', 'no truncation needed');
+assert(truncate('hello world', 8) === 'hello...', 'truncate to 8 (5+3)');
+assert(truncate('abcdefghij', 7) === 'abcd...', 'truncate to 7 (4+3)');
+
+// matrixBorder tests
+const m = [[1,2,3],[4,5,6],[7,8,9]];
+const border = matrixBorder(m);
+assert(border.includes(1) && border.includes(2) && border.includes(3), 'top row in border');
+assert(border.includes(6) && border.includes(9), 'right col in border');
+assert(border.includes(7) && border.includes(8), 'bottom row in border');
+assert(border.includes(4), 'left col in border');
+assert(!border.includes(5), 'center not in border');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/bug_offbyone/instruction.md
+++ b/tasks/bug_offbyone/instruction.md
@@ -1,0 +1,21 @@
+# Task: Fix Off-by-One Bugs
+
+You have a JavaScript utility module in `utils.js` with several off-by-one errors.
+
+## Your Goal
+
+1. Identify all off-by-one bugs in `utils.js`
+2. Fix each bug so that all test cases pass
+3. Make minimal changes — only fix the bugs, don't refactor
+
+## Requirements
+
+- Run the tests first to see which ones fail
+- Fix only the bugs, do NOT change the test file
+- Do NOT rewrite functions — make targeted fixes
+- All tests in `test.js` must pass after your fixes
+
+## Files
+
+- `utils.js` — The buggy module (edit this file)
+- `test.js` — Test suite (do not modify)

--- a/tasks/bug_offbyone/prompts/quality.md
+++ b/tasks/bug_offbyone/prompts/quality.md
@@ -1,0 +1,22 @@
+# Off-by-One Bug Fix Quality Rubric
+
+## Bug Detection (0–0.4)
+- 0.4: All 6 off-by-one bugs correctly identified and explained
+- 0.3: 5 bugs identified
+- 0.2: 3-4 bugs identified
+- 0.1: 1-2 bugs identified
+- 0.0: No bugs identified
+
+## Fix Quality (0–0.3)
+- 0.3: All fixes are minimal and targeted (only changed the boundary condition)
+- 0.2: Most fixes are minimal
+- 0.1: Some fixes involve unnecessary refactoring
+- 0.0: Rewrote functions instead of fixing
+
+## Root Cause Analysis (0–0.3)
+- 0.3: Explained the root cause of each off-by-one error
+- 0.2: Explained most
+- 0.1: Minimal explanation
+- 0.0: No explanation
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/bug_offbyone/skills/bug-detector/SKILL.md
+++ b/tasks/bug_offbyone/skills/bug-detector/SKILL.md
@@ -1,0 +1,31 @@
+# Bug Detector Skill
+
+## Purpose
+Detect and fix common programming bugs.
+
+## Common Bug Patterns
+
+### Off-by-One Errors
+- Array index bounds (0-based vs 1-based)
+- Loop boundary conditions (< vs <=)
+- Fence-post problems (n elements need n-1 separators)
+- Substring/slice end indices (exclusive vs inclusive)
+
+### Null/Undefined Reference
+- Missing null checks before property access
+- Optional chaining (?.) where needed
+- Default values for function parameters
+- Checking array/object existence before iteration
+
+### Race Conditions
+- Shared mutable state in async code
+- Missing await on async operations
+- Concurrent modifications to shared data
+- Order-dependent operations without proper synchronization
+
+## Debugging Workflow
+1. Read the code and test cases carefully
+2. Run existing tests to see which fail
+3. Identify the root cause of each failure
+4. Apply minimal, targeted fixes
+5. Verify all tests pass after fixes

--- a/tasks/bug_offbyone/solution/solve.sh
+++ b/tasks/bug_offbyone/solution/solve.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > utils.js << 'EOF'
+// Fixed: <= for inclusive end
+function range(start, end) {
+  const result = [];
+  for (let i = start; i <= end; i++) {
+    result.push(i);
+  }
+  return result;
+}
+
+// Fixed: 1-based page, so startIndex = (page-1) * pageSize
+function paginate(items, page, pageSize) {
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = startIndex + pageSize;
+  return items.slice(startIndex, endIndex);
+}
+
+// Fixed: left = mid + 1, right = sortedArr.length - 1, left <= right
+function binarySearch(sortedArr, target) {
+  let left = 0;
+  let right = sortedArr.length - 1;
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    if (sortedArr[mid] === target) return mid;
+    if (sortedArr[mid] < target) left = mid + 1;
+    else right = mid - 1;
+  }
+  return -1;
+}
+
+// Fixed: i < arr.length (not <=)
+function chunk(arr, size) {
+  const result = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
+// Fixed: total length including "..." should be <= maxLen
+function truncate(str, maxLen) {
+  if (str.length <= maxLen) return str;
+  return str.substring(0, maxLen - 3) + '...';
+}
+
+// Fixed: cols - 1 instead of cols, rows - 1 instead of rows
+function matrixBorder(matrix) {
+  if (!matrix || matrix.length === 0) return [];
+  const rows = matrix.length;
+  const cols = matrix[0].length;
+  const border = [];
+  for (let j = 0; j < cols; j++) border.push(matrix[0][j]);
+  for (let i = 1; i < rows; i++) border.push(matrix[i][cols - 1]);
+  if (rows > 1) {
+    for (let j = cols - 2; j >= 0; j--) border.push(matrix[rows - 1][j]);
+  }
+  for (let i = rows - 2; i >= 1; i--) border.push(matrix[i][0]);
+  return border;
+}
+
+module.exports = { range, paginate, binarySearch, chunk, truncate, matrixBorder };
+EOF

--- a/tasks/bug_offbyone/task.toml
+++ b/tasks/bug_offbyone/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "bug-detection"
+tags = ["bug", "off-by-one"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.7
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.3

--- a/tasks/bug_offbyone/tests/test.sh
+++ b/tasks/bug_offbyone/tests/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All tests pass"
+
+# Count individual pass lines
+PASS_COUNT=$(grep -c "PASS:" /tmp/test_output.txt || true)
+TOTAL_COUNT=$(grep -cE "PASS:|FAIL:" /tmp/test_output.txt || true)
+
+check '[ "$PASS_COUNT" -ge 15 ]' "At least 15 individual tests pass"
+
+# Verify the source was modified (not the test)
+ORIG_HASH="original"
+check 'test -f utils.js' "utils.js exists"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/bug_race/environment/Dockerfile
+++ b/tasks/bug_race/environment/Dockerfile
@@ -1,0 +1,163 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# Module with race condition bugs
+RUN cat > async-service.js << 'EOF'
+// Simulated async operations
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Bug 1: Missing await - returns promise instead of value
+async function fetchUserData(userId) {
+  const data = delay(10).then(() => ({ id: userId, name: `User ${userId}` }));
+  return data.name;
+}
+
+// Bug 2: Race condition in counter - concurrent increments
+let requestCount = 0;
+async function trackRequest(requestId) {
+  const current = requestCount;
+  await delay(5);
+  requestCount = current + 1;
+  return requestCount;
+}
+
+function getRequestCount() {
+  return requestCount;
+}
+
+function resetRequestCount() {
+  requestCount = 0;
+}
+
+// Bug 3: Missing await in error handling
+async function safeFetch(url) {
+  try {
+    const result = fetchData(url);
+    return { success: true, data: result };
+  } catch (e) {
+    return { success: false, error: e.message };
+  }
+}
+
+async function fetchData(url) {
+  await delay(5);
+  if (url === 'bad') throw new Error('Network error');
+  return { url, content: 'data' };
+}
+
+// Bug 4: Parallel operations treated as sequential, losing results
+async function processAllItems(items) {
+  const results = [];
+  for (const item of items) {
+    processItem(item).then(result => results.push(result));
+  }
+  return results;
+}
+
+async function processItem(item) {
+  await delay(5);
+  return { ...item, processed: true };
+}
+
+// Bug 5: Async forEach doesn't wait
+async function validateAll(items) {
+  const errors = [];
+  items.forEach(async (item) => {
+    await delay(5);
+    if (!item.name) {
+      errors.push(`Item ${item.id} missing name`);
+    }
+  });
+  return errors;
+}
+
+module.exports = {
+  fetchUserData,
+  trackRequest,
+  getRequestCount,
+  resetRequestCount,
+  safeFetch,
+  processAllItems,
+  processItem,
+  validateAll,
+};
+EOF
+
+# Test suite
+RUN cat > test.js << 'TESTEOF'
+const {
+  fetchUserData,
+  trackRequest,
+  getRequestCount,
+  resetRequestCount,
+  safeFetch,
+  processAllItems,
+  validateAll,
+} = require('./async-service');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+async function runTests() {
+  // fetchUserData
+  const user = await fetchUserData(42);
+  assert(user === 'User 42', 'fetchUserData returns name string');
+
+  // trackRequest - sequential should work
+  resetRequestCount();
+  await trackRequest('r1');
+  await trackRequest('r2');
+  await trackRequest('r3');
+  assert(getRequestCount() === 3, 'sequential trackRequest = 3');
+
+  // trackRequest - concurrent should also work
+  resetRequestCount();
+  await Promise.all([trackRequest('a'), trackRequest('b'), trackRequest('c')]);
+  assert(getRequestCount() === 3, 'concurrent trackRequest = 3');
+
+  // safeFetch - success
+  const good = await safeFetch('good');
+  assert(good.success === true, 'safeFetch good succeeds');
+  assert(good.data && good.data.url === 'good', 'safeFetch good has data');
+
+  // safeFetch - error
+  const bad = await safeFetch('bad');
+  assert(bad.success === false, 'safeFetch bad fails');
+  assert(bad.error === 'Network error', 'safeFetch bad has error message');
+
+  // processAllItems
+  const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+  const processed = await processAllItems(items);
+  assert(processed.length === 3, 'processAllItems returns 3 results');
+  assert(processed.every(p => p.processed === true), 'all items processed');
+
+  // validateAll
+  const badItems = [{ id: 1, name: 'ok' }, { id: 2 }, { id: 3, name: 'ok' }];
+  const errors = await validateAll(badItems);
+  assert(errors.length === 1, 'validateAll finds 1 error');
+  assert(errors[0].includes('2'), 'error mentions item 2');
+
+  console.log(`\n${passed}/${total} tests passed`);
+  process.exit(passed === total ? 0 : 1);
+}
+
+runTests().catch(e => {
+  console.error('Test runner error:', e);
+  process.exit(1);
+});
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/bug_race/instruction.md
+++ b/tasks/bug_race/instruction.md
@@ -1,0 +1,21 @@
+# Task: Fix Race Condition Bugs
+
+You have a JavaScript module in `async-service.js` with race condition bugs in async code.
+
+## Your Goal
+
+1. Identify all race condition bugs in `async-service.js`
+2. Fix each bug with proper async handling
+3. All tests in `test.js` must pass after your fixes
+
+## Requirements
+
+- Add proper await/async handling
+- Fix shared state mutation issues
+- Do NOT change the test file
+- Make minimal, targeted fixes
+
+## Files
+
+- `async-service.js` — The buggy module (edit this file)
+- `test.js` — Test suite (do not modify)

--- a/tasks/bug_race/prompts/quality.md
+++ b/tasks/bug_race/prompts/quality.md
@@ -1,0 +1,22 @@
+# Race Condition Bug Fix Quality Rubric
+
+## Bug Detection (0–0.3)
+- 0.3: All 5 race condition bugs identified (missing await, concurrent state, forEach async, parallel fire-and-forget, try-catch async)
+- 0.2: 3-4 identified
+- 0.1: 1-2 identified
+- 0.0: None identified
+
+## Fix Quality (0–0.4)
+- 0.4: All fixes correct (proper await, mutex/sequential for shared state, Promise.all for parallel, for-of for async iteration)
+- 0.3: Most fixes correct
+- 0.2: Some fixes correct
+- 0.1: Fixes attempted but still racy
+- 0.0: No fixes
+
+## Async Pattern Understanding (0–0.3)
+- 0.3: Demonstrates understanding of JS event loop, Promise behavior, and concurrency patterns
+- 0.2: Mostly understands
+- 0.1: Partial understanding
+- 0.0: No understanding shown
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/bug_race/skills/bug-detector/SKILL.md
+++ b/tasks/bug_race/skills/bug-detector/SKILL.md
@@ -1,0 +1,31 @@
+# Bug Detector Skill
+
+## Purpose
+Detect and fix common programming bugs.
+
+## Common Bug Patterns
+
+### Off-by-One Errors
+- Array index bounds (0-based vs 1-based)
+- Loop boundary conditions (< vs <=)
+- Fence-post problems (n elements need n-1 separators)
+- Substring/slice end indices (exclusive vs inclusive)
+
+### Null/Undefined Reference
+- Missing null checks before property access
+- Optional chaining (?.) where needed
+- Default values for function parameters
+- Checking array/object existence before iteration
+
+### Race Conditions
+- Shared mutable state in async code
+- Missing await on async operations
+- Concurrent modifications to shared data
+- Order-dependent operations without proper synchronization
+
+## Debugging Workflow
+1. Read the code and test cases carefully
+2. Run existing tests to see which fail
+3. Identify the root cause of each failure
+4. Apply minimal, targeted fixes
+5. Verify all tests pass after fixes

--- a/tasks/bug_race/solution/solve.sh
+++ b/tasks/bug_race/solution/solve.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > async-service.js << 'EOF'
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Fixed: await the promise before accessing .name
+async function fetchUserData(userId) {
+  const data = await delay(10).then(() => ({ id: userId, name: `User ${userId}` }));
+  return data.name;
+}
+
+// Fixed: use atomic increment pattern
+let requestCount = 0;
+let requestMutex = Promise.resolve();
+async function trackRequest(requestId) {
+  await (requestMutex = requestMutex.then(async () => {
+    await delay(5);
+    requestCount++;
+  }));
+  return requestCount;
+}
+
+function getRequestCount() {
+  return requestCount;
+}
+
+function resetRequestCount() {
+  requestCount = 0;
+  requestMutex = Promise.resolve();
+}
+
+// Fixed: await fetchData
+async function safeFetch(url) {
+  try {
+    const result = await fetchData(url);
+    return { success: true, data: result };
+  } catch (e) {
+    return { success: false, error: e.message };
+  }
+}
+
+async function fetchData(url) {
+  await delay(5);
+  if (url === 'bad') throw new Error('Network error');
+  return { url, content: 'data' };
+}
+
+// Fixed: await all promises with Promise.all
+async function processAllItems(items) {
+  const results = await Promise.all(items.map(item => processItem(item)));
+  return results;
+}
+
+async function processItem(item) {
+  await delay(5);
+  return { ...item, processed: true };
+}
+
+// Fixed: use for-of instead of forEach for async
+async function validateAll(items) {
+  const errors = [];
+  for (const item of items) {
+    await delay(5);
+    if (!item.name) {
+      errors.push(`Item ${item.id} missing name`);
+    }
+  }
+  return errors;
+}
+
+module.exports = {
+  fetchUserData,
+  trackRequest,
+  getRequestCount,
+  resetRequestCount,
+  safeFetch,
+  processAllItems,
+  processItem,
+  validateAll,
+};
+EOF

--- a/tasks/bug_race/task.toml
+++ b/tasks/bug_race/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "bug-detection"
+tags = ["bug", "race-condition"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.7
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.3

--- a/tasks/bug_race/tests/test.sh
+++ b/tasks/bug_race/tests/test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+timeout 30 node test.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All tests pass"
+
+PASS_COUNT=$(grep -c "PASS:" /tmp/test_output.txt || true)
+check '[ "$PASS_COUNT" -ge 8 ]' "At least 8 individual tests pass"
+
+SOURCE=$(cat async-service.js)
+
+# Check proper await usage
+AWAIT_COUNT=$(echo "$SOURCE" | grep -c "await" || true)
+check '[ "$AWAIT_COUNT" -ge 8 ]' "Sufficient await usage"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/perf_algorithm/environment/Dockerfile
+++ b/tasks/perf_algorithm/environment/Dockerfile
@@ -1,0 +1,172 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# Utility module with poor performance
+RUN cat > utils.js << 'EOF'
+// Find duplicates in array - O(n²)
+function findDuplicates(arr) {
+  const dupes = [];
+  for (let i = 0; i < arr.length; i++) {
+    for (let j = i + 1; j < arr.length; j++) {
+      if (arr[i] === arr[j] && !dupes.includes(arr[i])) {
+        dupes.push(arr[i]);
+      }
+    }
+  }
+  return dupes;
+}
+
+// Find intersection of two arrays - O(n*m)
+function intersection(arr1, arr2) {
+  const result = [];
+  for (const item of arr1) {
+    for (const item2 of arr2) {
+      if (item === item2 && !result.includes(item)) {
+        result.push(item);
+      }
+    }
+  }
+  return result;
+}
+
+// Group by key - O(n²) due to find
+function groupBy(arr, key) {
+  const groups = [];
+  for (const item of arr) {
+    let found = false;
+    for (const group of groups) {
+      if (group.key === item[key]) {
+        group.items.push(item);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      groups.push({ key: item[key], items: [item] });
+    }
+  }
+  return groups;
+}
+
+// Find two numbers that sum to target - O(n²)
+function twoSum(nums, target) {
+  for (let i = 0; i < nums.length; i++) {
+    for (let j = i + 1; j < nums.length; j++) {
+      if (nums[i] + nums[j] === target) {
+        return [i, j];
+      }
+    }
+  }
+  return null;
+}
+
+// Count frequency of each element - O(n²)
+function frequency(arr) {
+  const result = [];
+  for (const item of arr) {
+    let found = false;
+    for (const entry of result) {
+      if (entry.value === item) {
+        entry.count++;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      result.push({ value: item, count: 1 });
+    }
+  }
+  return result;
+}
+
+module.exports = { findDuplicates, intersection, groupBy, twoSum, frequency };
+EOF
+
+# Correctness tests
+RUN cat > test_correctness.js << 'EOF'
+const { findDuplicates, intersection, groupBy, twoSum, frequency } = require('./utils');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+function arrEq(a, b) {
+  if (!a || !b) return a === b;
+  return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+}
+
+// findDuplicates tests
+assert(arrEq(findDuplicates([1,2,3,2,4,3]), [2,3]), 'findDuplicates basic');
+assert(arrEq(findDuplicates([1,2,3]), []), 'findDuplicates no dupes');
+assert(arrEq(findDuplicates([]), []), 'findDuplicates empty');
+
+// intersection tests
+assert(arrEq(intersection([1,2,3], [2,3,4]), [2,3]), 'intersection basic');
+assert(arrEq(intersection([1,2], [3,4]), []), 'intersection no overlap');
+assert(arrEq(intersection([], [1,2]), []), 'intersection empty');
+
+// groupBy tests
+const data = [{name:'a',cat:'x'},{name:'b',cat:'y'},{name:'c',cat:'x'}];
+const groups = groupBy(data, 'cat');
+assert(groups.length === 2, 'groupBy count');
+const xGroup = groups.find(g => g.key === 'x');
+assert(xGroup && xGroup.items.length === 2, 'groupBy x items');
+
+// twoSum tests
+assert(arrEq(twoSum([2,7,11,15], 9), [0,1]), 'twoSum basic');
+assert(twoSum([1,2,3], 10) === null, 'twoSum no match');
+
+// frequency tests
+const freq = frequency(['a','b','a','c','b','a']);
+const aFreq = freq.find(f => f.value === 'a');
+assert(aFreq && aFreq.count === 3, 'frequency count');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+EOF
+
+# Benchmark
+RUN cat > bench.js << 'EOF'
+const { findDuplicates, intersection, groupBy, twoSum, frequency } = require('./utils');
+
+const N = 10000;
+const arr = Array.from({length: N}, (_, i) => i % (N/2));
+const arr2 = Array.from({length: N}, (_, i) => i % (N/3));
+const objects = arr.map((v, i) => ({id: i, cat: `cat${v % 10}`}));
+
+console.log('Benchmarking with N =', N);
+
+let start;
+
+start = Date.now();
+findDuplicates(arr);
+console.log(`findDuplicates: ${Date.now() - start}ms`);
+
+start = Date.now();
+intersection(arr, arr2);
+console.log(`intersection: ${Date.now() - start}ms`);
+
+start = Date.now();
+groupBy(objects, 'cat');
+console.log(`groupBy: ${Date.now() - start}ms`);
+
+start = Date.now();
+twoSum(arr, N - 1);
+console.log(`twoSum: ${Date.now() - start}ms`);
+
+start = Date.now();
+frequency(arr);
+console.log(`frequency: ${Date.now() - start}ms`);
+EOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/perf_algorithm/instruction.md
+++ b/tasks/perf_algorithm/instruction.md
@@ -1,0 +1,22 @@
+# Task: Optimize Algorithm Performance
+
+You have a JavaScript utility module in `utils.js` with several functions that have suboptimal algorithmic complexity.
+
+## Your Goal
+
+1. Identify functions with poor algorithmic complexity
+2. Optimize each function while maintaining the same input/output behavior
+3. The optimized code must pass all correctness tests
+
+## Requirements
+
+- Reduce time complexity where possible (e.g., O(n²) → O(n), O(n) → O(1))
+- Do NOT change function signatures or return value formats
+- Do NOT import external libraries
+- The functions must produce identical results for all inputs
+
+## Files
+
+- `utils.js` — The module to optimize (edit this file)
+- `test_correctness.js` — Correctness tests (do not modify)
+- `bench.js` — Benchmark script (do not modify)

--- a/tasks/perf_algorithm/prompts/quality.md
+++ b/tasks/perf_algorithm/prompts/quality.md
@@ -1,0 +1,22 @@
+# Algorithm Optimization Quality Rubric
+
+## Optimization Correctness (0–0.4)
+- 0.4: All 5 functions optimized to better complexity while maintaining correctness
+- 0.3: 4 of 5 optimized correctly
+- 0.2: 2-3 optimized correctly
+- 0.1: 1 optimized correctly
+- 0.0: No valid optimizations
+
+## Technique Quality (0–0.3)
+- 0.3: Uses appropriate data structures (Set, Map) for each case
+- 0.2: Uses some appropriate data structures
+- 0.1: Attempts optimization but suboptimal approach
+- 0.0: No meaningful technique improvement
+
+## Explanation (0–0.3)
+- 0.3: Explains complexity before/after for each function
+- 0.2: Explains some optimizations
+- 0.1: Minimal explanation
+- 0.0: No explanation
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/perf_algorithm/skills/perf-analyzer/SKILL.md
+++ b/tasks/perf_algorithm/skills/perf-analyzer/SKILL.md
@@ -1,0 +1,27 @@
+# Performance Analyzer Skill
+
+## Purpose
+Detect and fix performance issues in source code.
+
+## Key Patterns
+
+### Algorithm Complexity
+- Identify O(n²) or worse algorithms that can be O(n) or O(n log n)
+- Look for nested loops over the same dataset
+- Consider using hash maps/sets for O(1) lookups instead of array scans
+
+### Database Query Optimization
+- Identify N+1 query patterns (query in a loop)
+- Use JOINs or batch queries instead of per-item queries
+- Add appropriate indexes
+
+### React Re-render Prevention
+- Use React.memo for components that receive the same props
+- Use useMemo/useCallback to memoize expensive computations
+- Avoid creating new objects/arrays in render
+
+## Workflow
+1. Read the code and identify performance bottlenecks
+2. Analyze the algorithmic complexity
+3. Apply targeted optimizations
+4. Verify the fix maintains correctness

--- a/tasks/perf_algorithm/solution/solve.sh
+++ b/tasks/perf_algorithm/solution/solve.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > utils.js << 'EOF'
+// Find duplicates in array - O(n) using Set
+function findDuplicates(arr) {
+  const seen = new Set();
+  const dupes = new Set();
+  for (const item of arr) {
+    if (seen.has(item)) {
+      dupes.add(item);
+    }
+    seen.add(item);
+  }
+  return [...dupes];
+}
+
+// Find intersection of two arrays - O(n+m) using Set
+function intersection(arr1, arr2) {
+  const set2 = new Set(arr2);
+  const result = new Set();
+  for (const item of arr1) {
+    if (set2.has(item)) {
+      result.add(item);
+    }
+  }
+  return [...result];
+}
+
+// Group by key - O(n) using Map
+function groupBy(arr, key) {
+  const map = new Map();
+  for (const item of arr) {
+    const k = item[key];
+    if (!map.has(k)) {
+      map.set(k, { key: k, items: [] });
+    }
+    map.get(k).items.push(item);
+  }
+  return [...map.values()];
+}
+
+// Find two numbers that sum to target - O(n) using Map
+function twoSum(nums, target) {
+  const map = new Map();
+  for (let i = 0; i < nums.length; i++) {
+    const complement = target - nums[i];
+    if (map.has(complement)) {
+      return [map.get(complement), i];
+    }
+    map.set(nums[i], i);
+  }
+  return null;
+}
+
+// Count frequency of each element - O(n) using Map
+function frequency(arr) {
+  const map = new Map();
+  for (const item of arr) {
+    map.set(item, (map.get(item) || 0) + 1);
+  }
+  return [...map.entries()].map(([value, count]) => ({ value, count }));
+}
+
+module.exports = { findDuplicates, intersection, groupBy, twoSum, frequency };
+EOF

--- a/tasks/perf_algorithm/task.toml
+++ b/tasks/perf_algorithm/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "performance"
+tags = ["performance", "algorithm"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.6
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.4

--- a/tasks/perf_algorithm/tests/test.sh
+++ b/tasks/perf_algorithm/tests/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+# Correctness tests must pass
+node test_correctness.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All correctness tests pass"
+
+SOURCE=$(cat utils.js)
+
+# Check that nested loops are reduced
+# findDuplicates should use Set or Map
+check 'echo "$SOURCE" | grep -qE "new Set|new Map|Set\(|Map\("' "Uses Set or Map data structures"
+
+# Should not have O(n²) patterns: nested for loops with same array
+NESTED_LOOPS=$(echo "$SOURCE" | grep -c "for.*for" || true)
+check '[ "$NESTED_LOOPS" -le 1 ]' "Reduced nested loop count"
+
+# Check if includes() is removed from hot paths (was cause of O(n²))
+INCLUDES_COUNT=$(echo "$SOURCE" | grep -c "\.includes(" || true)
+check '[ "$INCLUDES_COUNT" -le 1 ]' "Removed .includes() from hot loops"
+
+# Run benchmark and check timing
+node bench.js > /tmp/bench_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/bench_output.txt
+
+# Check that findDuplicates is under 100ms (was >1000ms for N=10000)
+FIND_DUP_TIME=$(grep "findDuplicates:" /tmp/bench_output.txt | grep -oP '\d+' | tail -1)
+check '[ "${FIND_DUP_TIME:-9999}" -lt 100 ]' "findDuplicates < 100ms"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/perf_nplus1/environment/Dockerfile
+++ b/tasks/perf_nplus1/environment/Dockerfile
@@ -1,0 +1,122 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+RUN npm init -y && npm install better-sqlite3
+
+# Database setup
+RUN cat > db.js << 'DBEOF'
+const Database = require('better-sqlite3');
+const db = new Database(':memory:');
+
+db.exec(`
+  CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT, country TEXT);
+  CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, author_id INTEGER, year INTEGER);
+  CREATE TABLE reviews (id INTEGER PRIMARY KEY, book_id INTEGER, rating INTEGER, comment TEXT);
+`);
+
+// Insert test data
+const insertAuthor = db.prepare('INSERT INTO authors (id, name, country) VALUES (?, ?, ?)');
+const insertBook = db.prepare('INSERT INTO books (id, title, author_id, year) VALUES (?, ?, ?, ?)');
+const insertReview = db.prepare('INSERT INTO reviews (id, book_id, rating, comment) VALUES (?, ?, ?, ?)');
+
+const authors = [
+  [1, 'Alice Smith', 'US'], [2, 'Bob Jones', 'UK'], [3, 'Charlie Brown', 'CA'],
+  [4, 'Diana Lee', 'US'], [5, 'Eve Wilson', 'UK']
+];
+const books = [
+  [1, 'Book A', 1, 2020], [2, 'Book B', 1, 2021], [3, 'Book C', 2, 2019],
+  [4, 'Book D', 3, 2022], [5, 'Book E', 3, 2023], [6, 'Book F', 4, 2021],
+  [7, 'Book G', 5, 2020], [8, 'Book H', 5, 2022]
+];
+const reviews = [
+  [1, 1, 5, 'Great'], [2, 1, 4, 'Good'], [3, 2, 3, 'OK'],
+  [4, 3, 5, 'Excellent'], [5, 4, 2, 'Poor'], [6, 5, 4, 'Nice'],
+  [7, 6, 3, 'Average'], [8, 7, 5, 'Amazing'], [9, 8, 4, 'Solid']
+];
+
+authors.forEach(a => insertAuthor.run(...a));
+books.forEach(b => insertBook.run(...b));
+reviews.forEach(r => insertReview.run(...r));
+
+module.exports = db;
+DBEOF
+
+# App with N+1 queries
+RUN cat > app.js << 'APPEOF'
+const db = require('./db');
+
+// N+1: Fetches all authors, then queries books for each author
+function getAuthorsWithBooks() {
+  const authors = db.prepare('SELECT * FROM authors').all();
+  for (const author of authors) {
+    author.books = db.prepare('SELECT * FROM books WHERE author_id = ?').all(author.id);
+  }
+  return authors;
+}
+
+// N+1: Fetches all books, then queries author and reviews for each
+function getBooksWithDetails() {
+  const books = db.prepare('SELECT * FROM books').all();
+  for (const book of books) {
+    book.author = db.prepare('SELECT * FROM authors WHERE id = ?').get(book.author_id);
+    book.reviews = db.prepare('SELECT * FROM reviews WHERE book_id = ?').all(book.id);
+  }
+  return books;
+}
+
+// N+1: Gets authors from a country, then counts books for each
+function getAuthorBookCounts(country) {
+  const authors = db.prepare('SELECT * FROM authors WHERE country = ?').all(country);
+  for (const author of authors) {
+    const result = db.prepare('SELECT COUNT(*) as count FROM books WHERE author_id = ?').get(author.id);
+    author.bookCount = result.count;
+  }
+  return authors;
+}
+
+module.exports = { getAuthorsWithBooks, getBooksWithDetails, getAuthorBookCounts };
+APPEOF
+
+# Correctness tests
+RUN cat > test_correctness.js << 'TESTEOF'
+const { getAuthorsWithBooks, getBooksWithDetails, getAuthorBookCounts } = require('./app');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// Test getAuthorsWithBooks
+const authors = getAuthorsWithBooks();
+assert(authors.length === 5, 'getAuthorsWithBooks returns 5 authors');
+const alice = authors.find(a => a.name === 'Alice Smith');
+assert(alice && alice.books && alice.books.length === 2, 'Alice has 2 books');
+assert(alice.books[0].title === 'Book A' || alice.books[1].title === 'Book A', 'Alice has Book A');
+
+// Test getBooksWithDetails
+const books = getBooksWithDetails();
+assert(books.length === 8, 'getBooksWithDetails returns 8 books');
+const bookA = books.find(b => b.title === 'Book A');
+assert(bookA && bookA.author && bookA.author.name === 'Alice Smith', 'Book A author is Alice');
+assert(bookA && bookA.reviews && bookA.reviews.length === 2, 'Book A has 2 reviews');
+
+// Test getAuthorBookCounts
+const usAuthors = getAuthorBookCounts('US');
+assert(usAuthors.length === 2, 'US has 2 authors');
+const aliceCount = usAuthors.find(a => a.name === 'Alice Smith');
+assert(aliceCount && aliceCount.bookCount === 2, 'Alice bookCount is 2');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/perf_nplus1/instruction.md
+++ b/tasks/perf_nplus1/instruction.md
@@ -1,0 +1,22 @@
+# Task: Fix N+1 Query Performance Issue
+
+You have a Node.js application in `app.js` that suffers from N+1 query problems when fetching data from a SQLite database.
+
+## Your Goal
+
+1. Identify all N+1 query patterns in `app.js`
+2. Fix each by using JOINs or batch queries
+3. The optimized code must produce identical results
+
+## Requirements
+
+- Replace loops with individual queries by using JOINs or WHERE IN clauses
+- Do NOT change the response format (same JSON structure)
+- Do NOT modify the database schema
+- The fixed code must pass all correctness tests
+
+## Files
+
+- `app.js` — The application with N+1 queries (edit this file)
+- `db.js` — Database setup (do not modify)
+- `test_correctness.js` — Correctness tests (do not modify)

--- a/tasks/perf_nplus1/prompts/quality.md
+++ b/tasks/perf_nplus1/prompts/quality.md
@@ -1,0 +1,22 @@
+# N+1 Query Fix Quality Rubric
+
+## Fix Correctness (0–0.4)
+- 0.4: All 3 functions fixed, N+1 eliminated, results identical
+- 0.3: 2 of 3 functions fixed correctly
+- 0.2: 1 function fixed correctly
+- 0.1: Attempted but broken results
+- 0.0: No fixes
+
+## Technique (0–0.3)
+- 0.3: Uses JOINs and/or WHERE IN efficiently; minimal query count
+- 0.2: Uses batch queries but not optimal
+- 0.1: Reduces queries but still suboptimal
+- 0.0: Still has N+1 pattern
+
+## Explanation (0–0.3)
+- 0.3: Clearly explains N+1 problem and how JOINs/batching solves it
+- 0.2: Partial explanation
+- 0.1: Minimal explanation
+- 0.0: No explanation
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/perf_nplus1/skills/perf-analyzer/SKILL.md
+++ b/tasks/perf_nplus1/skills/perf-analyzer/SKILL.md
@@ -1,0 +1,27 @@
+# Performance Analyzer Skill
+
+## Purpose
+Detect and fix performance issues in source code.
+
+## Key Patterns
+
+### Algorithm Complexity
+- Identify O(n²) or worse algorithms that can be O(n) or O(n log n)
+- Look for nested loops over the same dataset
+- Consider using hash maps/sets for O(1) lookups instead of array scans
+
+### Database Query Optimization
+- Identify N+1 query patterns (query in a loop)
+- Use JOINs or batch queries instead of per-item queries
+- Add appropriate indexes
+
+### React Re-render Prevention
+- Use React.memo for components that receive the same props
+- Use useMemo/useCallback to memoize expensive computations
+- Avoid creating new objects/arrays in render
+
+## Workflow
+1. Read the code and identify performance bottlenecks
+2. Analyze the algorithmic complexity
+3. Apply targeted optimizations
+4. Verify the fix maintains correctness

--- a/tasks/perf_nplus1/solution/solve.sh
+++ b/tasks/perf_nplus1/solution/solve.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > app.js << 'EOF'
+const db = require('./db');
+
+// FIXED: Single query with JOIN, then group in JS
+function getAuthorsWithBooks() {
+  const rows = db.prepare(`
+    SELECT a.*, b.id as book_id, b.title, b.author_id as b_author_id, b.year
+    FROM authors a
+    LEFT JOIN books b ON a.id = b.author_id
+  `).all();
+
+  const authorMap = new Map();
+  for (const row of rows) {
+    if (!authorMap.has(row.id)) {
+      authorMap.set(row.id, { id: row.id, name: row.name, country: row.country, books: [] });
+    }
+    if (row.book_id) {
+      authorMap.get(row.id).books.push({ id: row.book_id, title: row.title, author_id: row.b_author_id, year: row.year });
+    }
+  }
+  return [...authorMap.values()];
+}
+
+// FIXED: Two queries (books+authors JOIN, then batch reviews)
+function getBooksWithDetails() {
+  const books = db.prepare(`
+    SELECT b.*, a.id as a_id, a.name as a_name, a.country as a_country
+    FROM books b
+    JOIN authors a ON b.author_id = a.id
+  `).all();
+
+  const allReviews = db.prepare('SELECT * FROM reviews').all();
+  const reviewMap = new Map();
+  for (const r of allReviews) {
+    if (!reviewMap.has(r.book_id)) reviewMap.set(r.book_id, []);
+    reviewMap.get(r.book_id).push(r);
+  }
+
+  return books.map(b => ({
+    id: b.id, title: b.title, author_id: b.author_id, year: b.year,
+    author: { id: b.a_id, name: b.a_name, country: b.a_country },
+    reviews: reviewMap.get(b.id) || []
+  }));
+}
+
+// FIXED: Single query with JOIN and COUNT
+function getAuthorBookCounts(country) {
+  return db.prepare(`
+    SELECT a.*, COUNT(b.id) as bookCount
+    FROM authors a
+    LEFT JOIN books b ON a.id = b.author_id
+    WHERE a.country = ?
+    GROUP BY a.id
+  `).all(country);
+}
+
+module.exports = { getAuthorsWithBooks, getBooksWithDetails, getAuthorBookCounts };
+EOF

--- a/tasks/perf_nplus1/task.toml
+++ b/tasks/perf_nplus1/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "performance"
+tags = ["performance", "database"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.6
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.4

--- a/tasks/perf_nplus1/tests/test.sh
+++ b/tasks/perf_nplus1/tests/test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test_correctness.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All correctness tests pass"
+
+SOURCE=$(cat app.js)
+
+# Check that N+1 patterns are removed
+# Count queries inside for/forEach loops
+LOOP_QUERIES=$(echo "$SOURCE" | grep -cP "for.*\{" || true)
+PREPARE_IN_FUNC=$(echo "$SOURCE" | grep -c "db.prepare" || true)
+
+# Should have fewer prepare calls (JOINs reduce query count)
+check '[ "$PREPARE_IN_FUNC" -le 6 ]' "Reduced number of db.prepare calls (was 8+)"
+
+# Should use JOIN or WHERE IN
+check 'echo "$SOURCE" | grep -qiE "JOIN|WHERE.*IN\s*\("' "Uses JOIN or WHERE IN clause"
+
+# Should not have prepare inside a for loop
+# Simple heuristic: check if there's a pattern of for...prepare on nearby lines
+LOOP_PREPARE=$(echo "$SOURCE" | awk '/for\s*\(|for\s*\(.*of|forEach/{found=1} found && /db\.prepare/{print; found=0}' | wc -l | tr -d ' ')
+check '[ "$LOOP_PREPARE" -eq 0 ]' "No db.prepare inside loops"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/perf_rerender/environment/Dockerfile
+++ b/tasks/perf_rerender/environment/Dockerfile
@@ -1,0 +1,132 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# React component with re-render issues
+RUN cat > App.jsx << 'JSXEOF'
+import React, { useState } from 'react';
+
+// Problem 1: Creates new object on every render
+function UserList({ users }) {
+  const [search, setSearch] = useState('');
+
+  const containerStyle = { padding: '20px', margin: '10px' };
+
+  const filtered = users.filter(u => u.name.toLowerCase().includes(search.toLowerCase()));
+
+  return (
+    <div style={containerStyle}>
+      <input value={search} onChange={e => setSearch(e.target.value)} />
+      {filtered.map(u => (
+        <UserCard key={u.id} user={u} onSelect={() => console.log(u.id)} />
+      ))}
+    </div>
+  );
+}
+
+// Problem 2: Re-renders even when props don't change
+function UserCard({ user, onSelect }) {
+  return (
+    <div onClick={onSelect}>
+      <h3>{user.name}</h3>
+      <p>{user.email}</p>
+    </div>
+  );
+}
+
+// Problem 3: Expensive computation on every render
+function Dashboard({ data }) {
+  const [tab, setTab] = useState('overview');
+
+  const stats = computeExpensiveStats(data);
+  const chartData = data.map(d => ({ x: d.date, y: d.value }));
+
+  return (
+    <div>
+      <button onClick={() => setTab('overview')}>Overview</button>
+      <button onClick={() => setTab('details')}>Details</button>
+      {tab === 'overview' && <StatsPanel stats={stats} />}
+      {tab === 'details' && <ChartPanel data={chartData} />}
+    </div>
+  );
+}
+
+// Problem 4: Re-renders child unnecessarily
+function StatsPanel({ stats }) {
+  return (
+    <div>
+      <p>Total: {stats.total}</p>
+      <p>Average: {stats.average}</p>
+    </div>
+  );
+}
+
+function ChartPanel({ data }) {
+  return (
+    <div>
+      {data.map((point, i) => (
+        <div key={i}>{point.x}: {point.y}</div>
+      ))}
+    </div>
+  );
+}
+
+function computeExpensiveStats(data) {
+  let total = 0;
+  for (const d of data) total += d.value;
+  return { total, average: total / data.length };
+}
+
+export { UserList, UserCard, Dashboard, StatsPanel, ChartPanel };
+JSXEOF
+
+# Static analysis tests
+RUN cat > test_checks.js << 'TESTEOF'
+const fs = require('fs');
+const source = fs.readFileSync('App.jsx', 'utf8');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// Check React.memo usage
+assert(source.includes('React.memo') || source.includes('memo('), 'Uses React.memo');
+
+// Check useMemo usage
+assert(source.includes('useMemo'), 'Uses useMemo');
+
+// Check useCallback usage
+assert(source.includes('useCallback'), 'Uses useCallback');
+
+// Check that containerStyle is memoized or moved outside
+const styleOutside = !source.match(/function UserList[\s\S]*?const containerStyle/);
+const styleMemoized = source.match(/useMemo\(\s*\(\)\s*=>\s*\(\s*\{.*padding/s) || source.match(/useMemo\(\s*\(\)\s*=>\s*\{.*padding/s);
+assert(styleOutside || styleMemoized || source.match(/const containerStyle[\s\S]*?useMemo/), 'Style object is stable (outside component or useMemo)');
+
+// Check that computeExpensiveStats result is memoized
+assert(source.includes('useMemo') && source.match(/useMemo\([\s\S]*?computeExpensiveStats/), 'computeExpensiveStats result is memoized');
+
+// Check inline function in map is memoized
+assert(source.includes('useCallback') && source.match(/useCallback\([\s\S]*?console\.log/), 'onSelect callback is memoized');
+
+// Components still exist
+assert(source.includes('UserList'), 'UserList exists');
+assert(source.includes('UserCard'), 'UserCard exists');
+assert(source.includes('Dashboard'), 'Dashboard exists');
+assert(source.includes('StatsPanel'), 'StatsPanel exists');
+assert(source.includes('ChartPanel'), 'ChartPanel exists');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/perf_rerender/instruction.md
+++ b/tasks/perf_rerender/instruction.md
@@ -1,0 +1,21 @@
+# Task: Fix Unnecessary React Re-renders
+
+You have a React component file `App.jsx` with performance issues caused by unnecessary re-renders.
+
+## Your Goal
+
+1. Identify all unnecessary re-render causes in `App.jsx`
+2. Fix each using React optimization techniques (memo, useMemo, useCallback)
+3. The optimized components must behave identically
+
+## Requirements
+
+- Use React.memo, useMemo, and/or useCallback appropriately
+- Do NOT change component behavior or visual output
+- Do NOT add external libraries
+- The fixed code must pass all tests
+
+## Files
+
+- `App.jsx` — The React components (edit this file)
+- `test_checks.js` — Static analysis tests (do not modify)

--- a/tasks/perf_rerender/prompts/quality.md
+++ b/tasks/perf_rerender/prompts/quality.md
@@ -1,0 +1,22 @@
+# React Re-render Fix Quality Rubric
+
+## Optimization Correctness (0–0.4)
+- 0.4: All re-render issues fixed (inline objects, callbacks, expensive computations, child components)
+- 0.3: 3 of 4 issues fixed
+- 0.2: 2 of 4 issues fixed
+- 0.1: 1 issue fixed
+- 0.0: No fixes
+
+## Technique Appropriateness (0–0.3)
+- 0.3: Correct use of React.memo, useMemo, useCallback in all cases
+- 0.2: Mostly correct but some misuse (e.g., unnecessary memoization)
+- 0.1: Some correct, some incorrect usage
+- 0.0: Incorrect or no optimization
+
+## Code Quality (0–0.3)
+- 0.3: Clean, readable code; dependencies arrays correct
+- 0.2: Minor issues in dependency arrays
+- 0.1: Missing or incorrect dependency arrays
+- 0.0: Broken code
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/perf_rerender/skills/perf-analyzer/SKILL.md
+++ b/tasks/perf_rerender/skills/perf-analyzer/SKILL.md
@@ -1,0 +1,27 @@
+# Performance Analyzer Skill
+
+## Purpose
+Detect and fix performance issues in source code.
+
+## Key Patterns
+
+### Algorithm Complexity
+- Identify O(n²) or worse algorithms that can be O(n) or O(n log n)
+- Look for nested loops over the same dataset
+- Consider using hash maps/sets for O(1) lookups instead of array scans
+
+### Database Query Optimization
+- Identify N+1 query patterns (query in a loop)
+- Use JOINs or batch queries instead of per-item queries
+- Add appropriate indexes
+
+### React Re-render Prevention
+- Use React.memo for components that receive the same props
+- Use useMemo/useCallback to memoize expensive computations
+- Avoid creating new objects/arrays in render
+
+## Workflow
+1. Read the code and identify performance bottlenecks
+2. Analyze the algorithmic complexity
+3. Apply targeted optimizations
+4. Verify the fix maintains correctness

--- a/tasks/perf_rerender/solution/solve.sh
+++ b/tasks/perf_rerender/solution/solve.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > App.jsx << 'EOF'
+import React, { useState, useMemo, useCallback, memo } from 'react';
+
+const containerStyle = { padding: '20px', margin: '10px' };
+
+function UserList({ users }) {
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(
+    () => users.filter(u => u.name.toLowerCase().includes(search.toLowerCase())),
+    [users, search]
+  );
+
+  const handleSelect = useCallback((id) => {
+    console.log(id);
+  }, []);
+
+  return (
+    <div style={containerStyle}>
+      <input value={search} onChange={e => setSearch(e.target.value)} />
+      {filtered.map(u => (
+        <UserCard key={u.id} user={u} onSelect={() => handleSelect(u.id)} />
+      ))}
+    </div>
+  );
+}
+
+const UserCard = memo(function UserCard({ user, onSelect }) {
+  return (
+    <div onClick={onSelect}>
+      <h3>{user.name}</h3>
+      <p>{user.email}</p>
+    </div>
+  );
+});
+
+function Dashboard({ data }) {
+  const [tab, setTab] = useState('overview');
+
+  const stats = useMemo(() => computeExpensiveStats(data), [data]);
+  const chartData = useMemo(() => data.map(d => ({ x: d.date, y: d.value })), [data]);
+
+  return (
+    <div>
+      <button onClick={() => setTab('overview')}>Overview</button>
+      <button onClick={() => setTab('details')}>Details</button>
+      {tab === 'overview' && <StatsPanel stats={stats} />}
+      {tab === 'details' && <ChartPanel data={chartData} />}
+    </div>
+  );
+}
+
+const StatsPanel = memo(function StatsPanel({ stats }) {
+  return (
+    <div>
+      <p>Total: {stats.total}</p>
+      <p>Average: {stats.average}</p>
+    </div>
+  );
+});
+
+const ChartPanel = memo(function ChartPanel({ data }) {
+  return (
+    <div>
+      {data.map((point, i) => (
+        <div key={i}>{point.x}: {point.y}</div>
+      ))}
+    </div>
+  );
+});
+
+function computeExpensiveStats(data) {
+  let total = 0;
+  for (const d of data) total += d.value;
+  return { total, average: total / data.length };
+}
+
+export { UserList, UserCard, Dashboard, StatsPanel, ChartPanel };
+EOF

--- a/tasks/perf_rerender/task.toml
+++ b/tasks/perf_rerender/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "performance"
+tags = ["performance", "react"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.6
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.4

--- a/tasks/perf_rerender/tests/test.sh
+++ b/tasks/perf_rerender/tests/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test_checks.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All static analysis tests pass"
+
+SOURCE=$(cat App.jsx)
+
+# Verify memo usage
+check 'echo "$SOURCE" | grep -qE "React\.memo|memo\("' "Uses React.memo"
+check 'echo "$SOURCE" | grep -q "useMemo"' "Uses useMemo"
+check 'echo "$SOURCE" | grep -q "useCallback"' "Uses useCallback"
+
+# Verify StatsPanel or ChartPanel is wrapped with memo
+check 'echo "$SOURCE" | grep -qE "memo\(.*StatsPanel|StatsPanel.*memo|memo\(.*ChartPanel|ChartPanel.*memo|memo\(.*UserCard|UserCard.*memo"' "At least one child component is memoized"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/security_path_traversal/environment/Dockerfile
+++ b/tasks/security_path_traversal/environment/Dockerfile
@@ -1,0 +1,111 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm init -y && npm install express
+
+# Create public directory with sample files
+RUN mkdir -p public/images public/docs
+RUN echo "Welcome to the site" > public/index.html
+RUN echo "Sample document" > public/docs/readme.txt
+RUN echo "Secret config" > /etc/secret.conf
+
+# Vulnerable application
+RUN cat > app.js << 'APPEOF'
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const app = express();
+
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+// VULN 1: Direct path concatenation
+app.get('/files/:filename', (req, res) => {
+  const filePath = PUBLIC_DIR + '/' + req.params.filename;
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    res.send(content);
+  } catch (e) {
+    res.status(404).send('File not found');
+  }
+});
+
+// VULN 2: Path traversal via query parameter
+app.get('/download', (req, res) => {
+  const { file } = req.query;
+  const filePath = path.join(PUBLIC_DIR, file);
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    res.send(content);
+  } catch (e) {
+    res.status(404).send('File not found');
+  }
+});
+
+// VULN 3: Directory listing with traversal
+app.get('/list', (req, res) => {
+  const dir = req.query.dir || '';
+  const dirPath = path.join(PUBLIC_DIR, dir);
+  try {
+    const files = fs.readdirSync(dirPath);
+    res.json(files);
+  } catch (e) {
+    res.status(404).json({ error: 'Directory not found' });
+  }
+});
+
+// VULN 4: File upload path traversal
+app.post('/upload', express.text(), (req, res) => {
+  const filename = req.query.name;
+  const filePath = path.join(PUBLIC_DIR, filename);
+  fs.writeFileSync(filePath, req.body);
+  res.json({ saved: filename });
+});
+
+module.exports = app;
+APPEOF
+
+# Functional tests
+RUN cat > test_functional.js << 'TESTEOF'
+const fs = require('fs');
+const path = require('path');
+const source = fs.readFileSync('app.js', 'utf8');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// Must use path.resolve or realpath for validation
+assert(source.includes('path.resolve') || source.includes('realpath') || source.includes('normalize'), 'Uses path resolution');
+
+// Must check that resolved path starts with base directory
+assert(source.includes('startsWith') || source.includes('indexOf'), 'Checks path prefix');
+
+// Must not have raw concatenation: PUBLIC_DIR + '/' +
+assert(!source.includes("PUBLIC_DIR + '/' +") && !source.includes('PUBLIC_DIR + "/" +'), 'No raw path concatenation');
+
+// Endpoints still exist
+assert(source.includes("'/files/:filename'") || source.includes('"/files/:filename"'), 'Files endpoint exists');
+assert(source.includes("'/download'") || source.includes('"/download"'), 'Download endpoint exists');
+assert(source.includes("'/list'") || source.includes('"/list"'), 'List endpoint exists');
+assert(source.includes("'/upload'") || source.includes('"/upload"'), 'Upload endpoint exists');
+
+// Should have error responses for traversal attempts
+assert(source.includes('403') || source.includes('forbidden') || source.includes('Forbidden') || source.includes('Access denied'), 'Returns 403 for traversal');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/security_path_traversal/instruction.md
+++ b/tasks/security_path_traversal/instruction.md
@@ -1,0 +1,23 @@
+# Task: Fix Path Traversal Vulnerabilities
+
+You have a Node.js Express file server in `app.js` that has path traversal vulnerabilities.
+
+## Your Goal
+
+1. Identify all path traversal vulnerabilities in `app.js`
+2. Fix each vulnerability by properly validating and sanitizing file paths
+3. Ensure the application still serves files correctly after fixes
+
+## Requirements
+
+- Validate that resolved file paths stay within the allowed directory
+- Use `path.resolve()` and check paths are within the base directory
+- Do NOT change the API endpoints or their routes
+- Do NOT remove any functionality — files should still be serveable
+- The fixed code must still pass the existing functionality tests
+
+## Files
+
+- `app.js` — The vulnerable application (edit this file)
+- `test_functional.js` — Functionality tests (do not modify)
+- `public/` — The allowed file serving directory (do not modify)

--- a/tasks/security_path_traversal/prompts/quality.md
+++ b/tasks/security_path_traversal/prompts/quality.md
@@ -1,0 +1,24 @@
+# Path Traversal Fix Quality Rubric
+
+Evaluate the agent's path traversal vulnerability remediation.
+
+## Vulnerability Detection (0–0.3)
+- 0.3: Identified all 4 path traversal points
+- 0.2: Identified 3 of 4
+- 0.1: Identified 1-2
+- 0.0: None identified
+
+## Fix Quality (0–0.4)
+- 0.4: Uses path.resolve + startsWith check consistently; returns 403 for traversal
+- 0.3: Mostly correct path validation
+- 0.2: Some paths validated but inconsistent
+- 0.1: Minimal validation
+- 0.0: No fixes
+
+## Robustness (0–0.3)
+- 0.3: Handles encoded paths (../, %2e%2e), null bytes, symlinks
+- 0.2: Handles basic traversal patterns
+- 0.1: Only handles simple cases
+- 0.0: Trivially bypassable
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/security_path_traversal/skills/security-scan/SKILL.md
+++ b/tasks/security_path_traversal/skills/security-scan/SKILL.md
@@ -1,0 +1,40 @@
+# Security Scan Skill
+
+## Purpose
+Detect and remediate security vulnerabilities in source code.
+
+## Key Patterns
+
+### SQL Injection Prevention
+- **Never** use string interpolation in SQL queries
+- **Always** use parameterized queries with `?` placeholders
+- **Whitelist** allowed values for ORDER BY, column names
+- **Validate** and cast numeric inputs (parseInt, etc.)
+
+### Common SQL Injection Patterns to Fix
+```javascript
+// BAD: String interpolation
+db.prepare(`SELECT * FROM users WHERE id = '${id}'`).all();
+
+// GOOD: Parameterized query
+db.prepare('SELECT * FROM users WHERE id = ?').all(id);
+```
+
+### ORDER BY Safety
+```javascript
+// BAD: Direct interpolation
+query += ` ORDER BY ${sort}`;
+
+// GOOD: Whitelist approach
+const allowedSorts = ['name', 'price', 'date'];
+if (allowedSorts.includes(sort)) {
+  query += ` ORDER BY ${sort}`;
+}
+```
+
+## Workflow
+1. Read the source code carefully
+2. Identify all points where user input reaches SQL queries
+3. Replace each with parameterized queries
+4. Handle special cases (ORDER BY, LIMIT) with whitelists
+5. Verify the fix doesn't break functionality

--- a/tasks/security_path_traversal/solution/solve.sh
+++ b/tasks/security_path_traversal/solution/solve.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > app.js << 'EOF'
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const app = express();
+
+const PUBLIC_DIR = path.resolve(__dirname, 'public');
+
+function safePath(base, userPath) {
+  const resolved = path.resolve(base, userPath);
+  if (!resolved.startsWith(base + path.sep) && resolved !== base) {
+    return null;
+  }
+  return resolved;
+}
+
+// FIXED: Path validation
+app.get('/files/:filename', (req, res) => {
+  const filePath = safePath(PUBLIC_DIR, req.params.filename);
+  if (!filePath) {
+    return res.status(403).send('Forbidden');
+  }
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    res.send(content);
+  } catch (e) {
+    res.status(404).send('File not found');
+  }
+});
+
+// FIXED: Path validation
+app.get('/download', (req, res) => {
+  const { file } = req.query;
+  const filePath = safePath(PUBLIC_DIR, file);
+  if (!filePath) {
+    return res.status(403).send('Forbidden');
+  }
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    res.send(content);
+  } catch (e) {
+    res.status(404).send('File not found');
+  }
+});
+
+// FIXED: Path validation
+app.get('/list', (req, res) => {
+  const dir = req.query.dir || '';
+  const dirPath = safePath(PUBLIC_DIR, dir);
+  if (!dirPath) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  try {
+    const files = fs.readdirSync(dirPath);
+    res.json(files);
+  } catch (e) {
+    res.status(404).json({ error: 'Directory not found' });
+  }
+});
+
+// FIXED: Path validation
+app.post('/upload', express.text(), (req, res) => {
+  const filename = req.query.name;
+  const filePath = safePath(PUBLIC_DIR, filename);
+  if (!filePath) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  fs.writeFileSync(filePath, req.body);
+  res.json({ saved: filename });
+});
+
+module.exports = app;
+EOF

--- a/tasks/security_path_traversal/task.toml
+++ b/tasks/security_path_traversal/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "security"
+tags = ["security", "path-traversal", "vulnerability"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.7
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.3

--- a/tasks/security_path_traversal/tests/test.sh
+++ b/tasks/security_path_traversal/tests/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test_functional.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+
+check '[ $FUNC_EXIT -eq 0 ]' "Functional tests pass"
+
+SOURCE=$(cat app.js)
+
+# Check path validation
+check 'echo "$SOURCE" | grep -q "path.resolve\|realpath"' "Uses path.resolve or realpath"
+check 'echo "$SOURCE" | grep -q "startsWith"' "Uses startsWith for prefix check"
+
+# Check no raw concatenation
+check '! echo "$SOURCE" | grep -qP "PUBLIC_DIR \+ ./" ' "No raw path concatenation"
+
+# Check 403 response
+check 'echo "$SOURCE" | grep -q "403"' "Returns 403 for path traversal"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/security_sqli/environment/Dockerfile
+++ b/tasks/security_sqli/environment/Dockerfile
@@ -1,0 +1,143 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm init -y && npm install express better-sqlite3
+
+# Database setup
+RUN cat > db.js << 'DBEOF'
+const Database = require('better-sqlite3');
+const path = require('path');
+
+const db = new Database(path.join(__dirname, 'app.db'));
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL,
+    email TEXT NOT NULL,
+    role TEXT DEFAULT 'user'
+  );
+  INSERT OR IGNORE INTO users (id, username, email, role) VALUES
+    (1, 'alice', 'alice@example.com', 'admin'),
+    (2, 'bob', 'bob@example.com', 'user'),
+    (3, 'charlie', 'charlie@example.com', 'user');
+
+  CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    price REAL NOT NULL,
+    category TEXT
+  );
+  INSERT OR IGNORE INTO products (id, name, price, category) VALUES
+    (1, 'Laptop', 999.99, 'electronics'),
+    (2, 'Book', 19.99, 'books'),
+    (3, 'Phone', 599.99, 'electronics');
+`);
+
+module.exports = db;
+DBEOF
+
+# Vulnerable application
+RUN cat > app.js << 'APPEOF'
+const express = require('express');
+const db = require('./db');
+const app = express();
+app.use(express.json());
+
+// VULN 1: SQL injection in search
+app.get('/api/users/search', (req, res) => {
+  const { username } = req.query;
+  const rows = db.prepare(`SELECT * FROM users WHERE username = '${username}'`).all();
+  res.json(rows);
+});
+
+// VULN 2: SQL injection in login check
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  const row = db.prepare(`SELECT * FROM users WHERE username = '${username}' AND role = '${password}'`).get();
+  if (row) {
+    res.json({ success: true, user: row });
+  } else {
+    res.json({ success: false });
+  }
+});
+
+// VULN 3: SQL injection in product filter
+app.get('/api/products', (req, res) => {
+  const { category, sort } = req.query;
+  let query = 'SELECT * FROM products';
+  if (category) {
+    query += ` WHERE category = '${category}'`;
+  }
+  if (sort) {
+    query += ` ORDER BY ${sort}`;
+  }
+  const rows = db.prepare(query).all();
+  res.json(rows);
+});
+
+// VULN 4: SQL injection in user deletion
+app.delete('/api/users/:id', (req, res) => {
+  const { id } = req.params;
+  db.prepare(`DELETE FROM users WHERE id = ${id}`).run();
+  res.json({ deleted: true });
+});
+
+module.exports = app;
+APPEOF
+
+# Functional tests
+RUN cat > test_functional.js << 'TESTEOF'
+const db = require('./db');
+const app = require('./app');
+
+// Simple test runner
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${msg}`);
+  } else {
+    console.log(`  FAIL: ${msg}`);
+  }
+}
+
+// Reset DB for tests
+db.exec("DELETE FROM users; INSERT INTO users (id, username, email, role) VALUES (1, 'alice', 'alice@example.com', 'admin'), (2, 'bob', 'bob@example.com', 'user'), (3, 'charlie', 'charlie@example.com', 'user');");
+
+// Test: source code should not have string interpolation in SQL
+const fs = require('fs');
+const source = fs.readFileSync('app.js', 'utf8');
+
+assert(!source.includes('`SELECT') && !source.match(/\$\{.*\}.*SELECT|SELECT.*\$\{/), 'No template literal interpolation in SQL queries');
+assert(source.includes('.prepare(') || source.includes('.run('), 'Still uses prepare statements');
+
+// Test: parameterized queries pattern
+const paramPatterns = [/\.prepare\([^)]*\?\s*[^)]*\)/, /\.prepare\([^`']*\)/];
+assert(paramPatterns.some(p => p.test(source)), 'Uses parameterized query syntax');
+
+// Test: endpoints still exist
+assert(source.includes("'/api/users/search'") || source.includes('"/api/users/search"'), 'Search endpoint exists');
+assert(source.includes("'/api/login'") || source.includes('"/api/login"'), 'Login endpoint exists');
+assert(source.includes("'/api/products'") || source.includes('"/api/products"'), 'Products endpoint exists');
+assert(source.includes("'/api/users/:id'") || source.includes('"/api/users/:id"'), 'Delete endpoint exists');
+
+// Test: ORDER BY should be whitelisted, not interpolated
+const orderBySection = source.substring(source.indexOf('/api/products'));
+assert(!orderBySection.includes('ORDER BY ${') && !orderBySection.includes("ORDER BY ' +"), 'ORDER BY is not directly interpolated');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/security_sqli/instruction.md
+++ b/tasks/security_sqli/instruction.md
@@ -1,0 +1,22 @@
+# Task: Fix SQL Injection Vulnerabilities
+
+You have a Node.js Express application in `app.js` that has SQL injection vulnerabilities.
+
+## Your Goal
+
+1. Identify all SQL injection vulnerabilities in `app.js`
+2. Fix each vulnerability by using parameterized queries
+3. Ensure the application still works correctly after fixes
+
+## Requirements
+
+- Use parameterized queries (placeholder `?`) instead of string concatenation
+- Do NOT change the API endpoints or their behavior
+- Do NOT change the database schema
+- The fixed code must still pass the existing functionality tests
+
+## Files
+
+- `app.js` — The vulnerable application (edit this file)
+- `db.js` — Database setup (do not modify)
+- `test_functional.js` — Functionality tests (do not modify)

--- a/tasks/security_sqli/prompts/quality.md
+++ b/tasks/security_sqli/prompts/quality.md
@@ -1,0 +1,24 @@
+# Security Fix Quality Rubric
+
+Evaluate the agent's security vulnerability remediation.
+
+## Vulnerability Detection (0–0.4)
+- 0.4: Identified all 4 SQL injection points (search, login, products, delete)
+- 0.3: Identified 3 of 4 vulnerabilities
+- 0.2: Identified 2 of 4 vulnerabilities
+- 0.1: Identified only 1 vulnerability
+- 0.0: Failed to identify any vulnerabilities
+
+## Fix Quality (0–0.4)
+- 0.4: All fixes use proper parameterized queries, ORDER BY is whitelisted
+- 0.3: Most fixes correct, minor issues
+- 0.2: Some fixes applied but inconsistent approach
+- 0.1: Attempted fixes but still vulnerable
+- 0.0: No meaningful fixes applied
+
+## Explanation (0–0.2)
+- 0.2: Clear explanation of each vulnerability and why the fix works
+- 0.1: Partial explanation
+- 0.0: No explanation provided
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/security_sqli/skills/security-scan/SKILL.md
+++ b/tasks/security_sqli/skills/security-scan/SKILL.md
@@ -1,0 +1,40 @@
+# Security Scan Skill
+
+## Purpose
+Detect and remediate security vulnerabilities in source code.
+
+## Key Patterns
+
+### SQL Injection Prevention
+- **Never** use string interpolation in SQL queries
+- **Always** use parameterized queries with `?` placeholders
+- **Whitelist** allowed values for ORDER BY, column names
+- **Validate** and cast numeric inputs (parseInt, etc.)
+
+### Common SQL Injection Patterns to Fix
+```javascript
+// BAD: String interpolation
+db.prepare(`SELECT * FROM users WHERE id = '${id}'`).all();
+
+// GOOD: Parameterized query
+db.prepare('SELECT * FROM users WHERE id = ?').all(id);
+```
+
+### ORDER BY Safety
+```javascript
+// BAD: Direct interpolation
+query += ` ORDER BY ${sort}`;
+
+// GOOD: Whitelist approach
+const allowedSorts = ['name', 'price', 'date'];
+if (allowedSorts.includes(sort)) {
+  query += ` ORDER BY ${sort}`;
+}
+```
+
+## Workflow
+1. Read the source code carefully
+2. Identify all points where user input reaches SQL queries
+3. Replace each with parameterized queries
+4. Handle special cases (ORDER BY, LIMIT) with whitelists
+5. Verify the fix doesn't break functionality

--- a/tasks/security_sqli/solution/solve.sh
+++ b/tasks/security_sqli/solution/solve.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > app.js << 'EOF'
+const express = require('express');
+const db = require('./db');
+const app = express();
+app.use(express.json());
+
+// FIXED: Parameterized query
+app.get('/api/users/search', (req, res) => {
+  const { username } = req.query;
+  const rows = db.prepare('SELECT * FROM users WHERE username = ?').all(username);
+  res.json(rows);
+});
+
+// FIXED: Parameterized query
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  const row = db.prepare('SELECT * FROM users WHERE username = ? AND role = ?').get(username, password);
+  if (row) {
+    res.json({ success: true, user: row });
+  } else {
+    res.json({ success: false });
+  }
+});
+
+// FIXED: Parameterized query + ORDER BY whitelist
+app.get('/api/products', (req, res) => {
+  const { category, sort } = req.query;
+  const allowedSorts = ['name', 'price', 'category'];
+  let query = 'SELECT * FROM products';
+  const params = [];
+  if (category) {
+    query += ' WHERE category = ?';
+    params.push(category);
+  }
+  if (sort && allowedSorts.includes(sort)) {
+    query += ` ORDER BY ${sort}`;
+  }
+  const rows = db.prepare(query).all(...params);
+  res.json(rows);
+});
+
+// FIXED: Parameterized query with integer validation
+app.delete('/api/users/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) {
+    return res.status(400).json({ error: 'Invalid ID' });
+  }
+  db.prepare('DELETE FROM users WHERE id = ?').run(id);
+  res.json({ deleted: true });
+});
+
+module.exports = app;
+EOF

--- a/tasks/security_sqli/task.toml
+++ b/tasks/security_sqli/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "security"
+tags = ["security", "sql-injection", "vulnerability"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.7
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.3

--- a/tasks/security_sqli/tests/test.sh
+++ b/tasks/security_sqli/tests/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+# Run functional tests
+node test_functional.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+
+check '[ $FUNC_EXIT -eq 0 ]' "Functional tests pass"
+
+# Check no template literals in SQL
+SOURCE=$(cat app.js)
+check '! echo "$SOURCE" | grep -qP "prepare\(\`.*\\\$\{" ' "No template literal SQL injection"
+check '! echo "$SOURCE" | grep -qP "prepare\(.*\x27.*\+.*\x27" ' "No string concatenation SQL injection"
+
+# Check parameterized queries used
+check 'echo "$SOURCE" | grep -q "?" ' "Uses parameterized queries with ?"
+
+# Check ORDER BY is safe (whitelist or removed)
+check '! echo "$SOURCE" | grep -qP "ORDER BY \\\$\{|ORDER BY.*\x27 \+" ' "ORDER BY is safely handled"
+
+# Calculate score
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/security_xss/environment/Dockerfile
+++ b/tasks/security_xss/environment/Dockerfile
@@ -1,0 +1,101 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm init -y && npm install express
+
+# Vulnerable application with XSS
+RUN cat > app.js << 'APPEOF'
+const express = require('express');
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+const messages = [];
+
+// VULN 1: Reflected XSS in search
+app.get('/search', (req, res) => {
+  const { q } = req.query;
+  res.send(`<html><body><h1>Search Results for: ${q}</h1><p>No results found.</p></body></html>`);
+});
+
+// VULN 2: Stored XSS in message board
+app.post('/messages', (req, res) => {
+  const { author, text } = req.body;
+  messages.push({ author, text, date: new Date().toISOString() });
+  res.redirect('/messages');
+});
+
+app.get('/messages', (req, res) => {
+  let html = '<html><body><h1>Messages</h1><ul>';
+  for (const msg of messages) {
+    html += `<li><strong>${msg.author}</strong>: ${msg.text} <em>(${msg.date})</em></li>`;
+  }
+  html += '</ul></body></html>';
+  res.send(html);
+});
+
+// VULN 3: DOM-based XSS via URL parameter in error page
+app.get('/error', (req, res) => {
+  const { message } = req.query;
+  res.send(`<html><body><div class="error"><h2>Error</h2><p>${message}</p></div></body></html>`);
+});
+
+// VULN 4: XSS in user profile rendering
+app.get('/profile/:name', (req, res) => {
+  const { name } = req.params;
+  const { bio } = req.query;
+  res.send(`<html><body><h1>Profile: ${name}</h1><div class="bio">${bio || 'No bio provided'}</div></body></html>`);
+});
+
+module.exports = app;
+APPEOF
+
+# Functional tests
+RUN cat > test_functional.js << 'TESTEOF'
+const fs = require('fs');
+const source = fs.readFileSync('app.js', 'utf8');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// Must have an escapeHtml function or equivalent
+assert(source.includes('escapeHtml') || source.includes('escape') || source.includes('sanitize') || source.includes('encode'), 'Has HTML escaping function');
+
+// Must not have direct template literal injection of user input
+const vulnPatterns = [
+  /\$\{q\}/,
+  /\$\{msg\.author\}/,
+  /\$\{msg\.text\}/,
+  /\$\{message\}/,
+  /\$\{name\}/,
+  /\$\{bio\}/
+];
+
+for (const pattern of vulnPatterns) {
+  assert(!pattern.test(source), `No direct interpolation: ${pattern.source}`);
+}
+
+// Endpoints still exist
+assert(source.includes("'/search'") || source.includes('"/search"'), 'Search endpoint exists');
+assert(source.includes("'/messages'") || source.includes('"/messages"'), 'Messages endpoint exists');
+assert(source.includes("'/error'") || source.includes('"/error"'), 'Error endpoint exists');
+assert(source.includes("'/profile/:name'") || source.includes('"/profile/:name"'), 'Profile endpoint exists');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/security_xss/instruction.md
+++ b/tasks/security_xss/instruction.md
@@ -1,0 +1,21 @@
+# Task: Fix Cross-Site Scripting (XSS) Vulnerabilities
+
+You have a Node.js Express application in `app.js` that serves HTML with XSS vulnerabilities.
+
+## Your Goal
+
+1. Identify all XSS vulnerabilities in `app.js`
+2. Fix each vulnerability by properly escaping/sanitizing output
+3. Ensure the application still renders correctly after fixes
+
+## Requirements
+
+- Properly escape HTML entities in all user-controlled output
+- Do NOT change the API endpoints or their routes
+- Do NOT add external sanitization libraries — implement escaping manually
+- The fixed code must still pass the existing functionality tests
+
+## Files
+
+- `app.js` — The vulnerable application (edit this file)
+- `test_functional.js` — Functionality tests (do not modify)

--- a/tasks/security_xss/prompts/quality.md
+++ b/tasks/security_xss/prompts/quality.md
@@ -1,0 +1,24 @@
+# XSS Fix Quality Rubric
+
+Evaluate the agent's XSS vulnerability remediation.
+
+## Vulnerability Detection (0–0.3)
+- 0.3: Identified all 4 XSS points (search, messages, error, profile)
+- 0.2: Identified 3 of 4
+- 0.1: Identified 1-2
+- 0.0: None identified
+
+## Fix Quality (0–0.4)
+- 0.4: Proper escapeHtml function covering &, <, >, ", '; applied to all user inputs
+- 0.3: Escape function exists and mostly correct
+- 0.2: Some outputs escaped but inconsistent
+- 0.1: Minimal/incorrect escaping
+- 0.0: No fixes
+
+## Completeness (0–0.3)
+- 0.3: All 4 endpoints fixed, no remaining XSS vectors
+- 0.2: 3 of 4 fixed
+- 0.1: 1-2 fixed
+- 0.0: None fixed
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/security_xss/skills/security-scan/SKILL.md
+++ b/tasks/security_xss/skills/security-scan/SKILL.md
@@ -1,0 +1,40 @@
+# Security Scan Skill
+
+## Purpose
+Detect and remediate security vulnerabilities in source code.
+
+## Key Patterns
+
+### SQL Injection Prevention
+- **Never** use string interpolation in SQL queries
+- **Always** use parameterized queries with `?` placeholders
+- **Whitelist** allowed values for ORDER BY, column names
+- **Validate** and cast numeric inputs (parseInt, etc.)
+
+### Common SQL Injection Patterns to Fix
+```javascript
+// BAD: String interpolation
+db.prepare(`SELECT * FROM users WHERE id = '${id}'`).all();
+
+// GOOD: Parameterized query
+db.prepare('SELECT * FROM users WHERE id = ?').all(id);
+```
+
+### ORDER BY Safety
+```javascript
+// BAD: Direct interpolation
+query += ` ORDER BY ${sort}`;
+
+// GOOD: Whitelist approach
+const allowedSorts = ['name', 'price', 'date'];
+if (allowedSorts.includes(sort)) {
+  query += ` ORDER BY ${sort}`;
+}
+```
+
+## Workflow
+1. Read the source code carefully
+2. Identify all points where user input reaches SQL queries
+3. Replace each with parameterized queries
+4. Handle special cases (ORDER BY, LIMIT) with whitelists
+5. Verify the fix doesn't break functionality

--- a/tasks/security_xss/solution/solve.sh
+++ b/tasks/security_xss/solution/solve.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > app.js << 'EOF'
+const express = require('express');
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+const messages = [];
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// FIXED: Escaped output
+app.get('/search', (req, res) => {
+  const { q } = req.query;
+  res.send(`<html><body><h1>Search Results for: ${escapeHtml(q)}</h1><p>No results found.</p></body></html>`);
+});
+
+// FIXED: Stored XSS prevention
+app.post('/messages', (req, res) => {
+  const { author, text } = req.body;
+  messages.push({ author, text, date: new Date().toISOString() });
+  res.redirect('/messages');
+});
+
+app.get('/messages', (req, res) => {
+  let html = '<html><body><h1>Messages</h1><ul>';
+  for (const msg of messages) {
+    html += `<li><strong>${escapeHtml(msg.author)}</strong>: ${escapeHtml(msg.text)} <em>(${msg.date})</em></li>`;
+  }
+  html += '</ul></body></html>';
+  res.send(html);
+});
+
+// FIXED: Escaped error message
+app.get('/error', (req, res) => {
+  const { message } = req.query;
+  res.send(`<html><body><div class="error"><h2>Error</h2><p>${escapeHtml(message)}</p></div></body></html>`);
+});
+
+// FIXED: Escaped profile data
+app.get('/profile/:name', (req, res) => {
+  const { name } = req.params;
+  const { bio } = req.query;
+  res.send(`<html><body><h1>Profile: ${escapeHtml(name)}</h1><div class="bio">${escapeHtml(bio) || 'No bio provided'}</div></body></html>`);
+});
+
+module.exports = app;
+EOF

--- a/tasks/security_xss/task.toml
+++ b/tasks/security_xss/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "medium"
+category = "security"
+tags = ["security", "xss", "vulnerability"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.7
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.3

--- a/tasks/security_xss/tests/test.sh
+++ b/tasks/security_xss/tests/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+# Run functional tests
+node test_functional.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+
+check '[ $FUNC_EXIT -eq 0 ]' "Functional tests pass"
+
+SOURCE=$(cat app.js)
+
+# Check escape function exists
+check 'echo "$SOURCE" | grep -qiE "escapehtml|escape_html|sanitize|htmlencode"' "Has HTML escape function"
+
+# Check escape function handles key characters
+check 'echo "$SOURCE" | grep -q "&amp;"' "Escapes ampersand"
+check 'echo "$SOURCE" | grep -q "&lt;"' "Escapes less-than"
+check 'echo "$SOURCE" | grep -q "&gt;"' "Escapes greater-than"
+
+# Calculate score
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/style_formatting/environment/Dockerfile
+++ b/tasks/style_formatting/environment/Dockerfile
@@ -1,0 +1,119 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# File with formatting violations
+COPY <<'EOF' app.js
+var express = require("express")
+var   path=require( "path" )
+
+var app = express()
+
+app.get("/hello",function(req,res){
+    var name = req.query.name || "World"
+    var greeting = "Hello, " + name + "!"
+    res.send( greeting )
+})
+
+app.get("/users",function(req,res){
+    var users = [
+        { "name": "Alice","age": 30 },
+        { "name":"Bob","age":25 },
+        {"name":"Charlie" ,"age":35}
+    ]
+    var filtered = users.filter(function(u){
+        return u.age > parseInt( req.query.min_age || "0" )
+    })
+    res.json( filtered )
+})
+
+app.get("/concat",function(req,res){
+    var firstName = req.query.first || "John"
+    var lastName = req.query.last || "Doe"
+    var fullName = firstName + " " + lastName
+    var message = "Welcome, " + fullName + "! You joined on " + new Date().toDateString() + "."
+    res.send(message)
+})
+
+app.get("/status", function( req, res ){
+    var status = {
+        "server": "running",
+        "uptime": process.uptime(),
+        "timestamp": new Date().toISOString()
+    }
+    res.json(status)
+})
+
+module.exports = app
+EOF
+
+# Tests
+COPY <<'TESTEOF' test_check.js
+const fs = require('fs');
+const source = fs.readFileSync('app.js', 'utf8');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// No var usage
+assert(!source.includes('var '), 'No var usage');
+
+// No double quotes (except inside template literals)
+const lines = source.split('\n');
+for (const line of lines) {
+  if (line.includes('"') && !line.includes('`')) {
+    assert(false, 'No double quotes: ' + line.trim().substring(0, 50));
+    break;
+  }
+}
+assert(!lines.some(l => l.includes('"') && !l.includes('`')), 'No double quotes overall');
+
+// Semicolons at end of statements
+const stmtLines = lines.filter(l => {
+  const trimmed = l.trim();
+  return trimmed && !trimmed.startsWith('//') && !trimmed.startsWith('*') &&
+    !trimmed.endsWith('{') && !trimmed.endsWith('}') && !trimmed.endsWith('(') &&
+    !trimmed.endsWith(',') && trimmed !== '' && !trimmed.startsWith('const') &&
+    trimmed.includes('=');
+});
+
+// Uses arrow functions
+assert(source.includes('=>'), 'Uses arrow functions');
+
+// No string concatenation with +
+assert(!source.match(/['"][^']*['"]\s*\+\s*\w/), 'No string concatenation with +');
+
+// Uses template literals
+assert(source.includes('`'), 'Uses template literals');
+
+// 2-space indentation (no 4-space or tab)
+const indentedLines = lines.filter(l => l.startsWith(' '));
+const has4Space = indentedLines.some(l => l.match(/^ {4}[^ ]/));
+const hasTab = lines.some(l => l.includes('\t'));
+assert(!hasTab, 'No tab indentation');
+
+// Module still works
+try {
+  const app = require('./app');
+  assert(typeof app === 'object' || typeof app === 'function', 'Module loads');
+} catch(e) {
+  assert(false, 'Module loads: ' + e.message);
+}
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN npm init -y && npm install express
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/style_formatting/instruction.md
+++ b/tasks/style_formatting/instruction.md
@@ -1,0 +1,26 @@
+# Task: Fix Code Formatting Issues
+
+You have a JavaScript file `app.js` with multiple formatting violations.
+
+## Your Goal
+
+1. Fix all formatting issues in `app.js`
+2. Follow these formatting rules:
+   - 2 spaces for indentation (not tabs, not 4 spaces)
+   - Single quotes for strings (not double quotes)
+   - Semicolons at end of statements
+   - No trailing whitespace
+   - Use `const` instead of `var`
+   - Use template literals instead of string concatenation
+   - Use arrow functions for callbacks
+
+## Requirements
+
+- Fix ALL formatting issues
+- Do NOT change the logic or behavior
+- The module must still work correctly
+
+## Files
+
+- `app.js` — The file with formatting issues (edit this file)
+- `test_check.js` — Tests (do not modify)

--- a/tasks/style_formatting/prompts/quality.md
+++ b/tasks/style_formatting/prompts/quality.md
@@ -1,0 +1,22 @@
+# Code Formatting Fix Quality Rubric
+
+## Formatting Compliance (0–0.5)
+- 0.5: All formatting rules followed (indentation, quotes, semicolons, var→const, template literals, arrow functions)
+- 0.4: Most rules followed (>90%)
+- 0.3: Majority followed (>70%)
+- 0.2: Some followed
+- 0.1: Few followed
+- 0.0: None followed
+
+## Consistency (0–0.3)
+- 0.3: Perfectly consistent formatting throughout
+- 0.2: Mostly consistent
+- 0.1: Inconsistent
+- 0.0: No consistency
+
+## Correctness (0–0.2)
+- 0.2: Code works identically after formatting fixes
+- 0.1: Minor behavior differences
+- 0.0: Code broken
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/style_formatting/skills/style-guide/SKILL.md
+++ b/tasks/style_formatting/skills/style-guide/SKILL.md
@@ -1,0 +1,31 @@
+# Style Guide Skill
+
+## Purpose
+Enforce consistent code style and naming conventions.
+
+## Naming Conventions
+- **Variables/Functions**: camelCase (`getUserName`, `totalCount`)
+- **Classes/Components**: PascalCase (`UserProfile`, `DataManager`)
+- **Constants**: UPPER_SNAKE_CASE (`MAX_RETRIES`, `API_BASE_URL`)
+- **Files**: kebab-case (`user-profile.js`, `data-manager.ts`)
+- **Private members**: prefix with underscore (`_internalState`)
+
+## Code Structure
+- Maximum function length: 30 lines
+- Maximum file length: 300 lines
+- One class/component per file
+- Group imports: external → internal → relative
+
+## Formatting
+- 2 spaces for indentation
+- Single quotes for strings
+- Semicolons required
+- Trailing commas in multiline
+- Max line length: 100 characters
+
+## Patterns
+- Prefer `const` over `let`, never use `var`
+- Use template literals over string concatenation
+- Use arrow functions for callbacks
+- Use destructuring where appropriate
+- Use optional chaining (?.) and nullish coalescing (??)

--- a/tasks/style_formatting/solution/solve.sh
+++ b/tasks/style_formatting/solution/solve.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > app.js << 'SOLEOF'
+const express = require('express');
+const path = require('path');
+
+const app = express();
+
+app.get('/hello', (req, res) => {
+  const name = req.query.name || 'World';
+  const greeting = `Hello, ${name}!`;
+  res.send(greeting);
+});
+
+app.get('/users', (req, res) => {
+  const users = [
+    { name: 'Alice', age: 30 },
+    { name: 'Bob', age: 25 },
+    { name: 'Charlie', age: 35 },
+  ];
+  const filtered = users.filter((u) => {
+    return u.age > parseInt(req.query.min_age || '0');
+  });
+  res.json(filtered);
+});
+
+app.get('/concat', (req, res) => {
+  const firstName = req.query.first || 'John';
+  const lastName = req.query.last || 'Doe';
+  const fullName = `${firstName} ${lastName}`;
+  const message = `Welcome, ${fullName}! You joined on ${new Date().toDateString()}.`;
+  res.send(message);
+});
+
+app.get('/status', (req, res) => {
+  const status = {
+    server: 'running',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  };
+  res.json(status);
+});
+
+module.exports = app;
+SOLEOF

--- a/tasks/style_formatting/task.toml
+++ b/tasks/style_formatting/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "easy"
+category = "style"
+tags = ["style", "formatting"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.8
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.2

--- a/tasks/style_formatting/tests/test.sh
+++ b/tasks/style_formatting/tests/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test_check.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All formatting tests pass"
+
+SOURCE=$(cat app.js)
+
+check '! echo "$SOURCE" | grep -q "var "' "No var usage"
+check 'echo "$SOURCE" | grep -q "=>"' "Uses arrow functions"
+check 'echo "$SOURCE" | grep -q "\`"' "Uses template literals"
+check '! echo "$SOURCE" | grep -qP "\t"' "No tab indentation"
+check 'node -e "require(\"./app\")"' "Module loads correctly"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/style_naming/environment/Dockerfile
+++ b/tasks/style_naming/environment/Dockerfile
@@ -1,0 +1,136 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# Module with naming convention violations
+RUN cat > utils.js << 'EOF'
+const max_retry_count = 3;
+const api_base_url = 'https://api.example.com';
+const Default_Timeout = 5000;
+
+class user_manager {
+  constructor() {
+    this.User_List = [];
+    this.active_count = 0;
+  }
+
+  Add_User(user_name, user_email) {
+    const New_User = {
+      user_name: user_name,
+      user_email: user_email,
+      Is_Active: true,
+    };
+    this.User_List.push(New_User);
+    this.active_count++;
+    return New_User;
+  }
+
+  get_user_by_name(Target_Name) {
+    return this.User_List.find(u => u.user_name === Target_Name);
+  }
+
+  Remove_User(user_name) {
+    const user_index = this.User_List.findIndex(u => u.user_name === user_name);
+    if (user_index !== -1) {
+      if (this.User_List[user_index].Is_Active) {
+        this.active_count--;
+      }
+      this.User_List.splice(user_index, 1);
+      return true;
+    }
+    return false;
+  }
+
+  get_Active_Users() {
+    return this.User_List.filter(u => u.Is_Active);
+  }
+}
+
+function Calculate_Average(number_array) {
+  if (number_array.length === 0) return 0;
+  const Total_Sum = number_array.reduce((acc, val) => acc + val, 0);
+  return Total_Sum / number_array.length;
+}
+
+function format_user_name(First_Name, Last_Name) {
+  return `${First_Name} ${Last_Name}`;
+}
+
+const is_valid_email = (email_string) => {
+  return email_string.includes('@') && email_string.includes('.');
+};
+
+module.exports = {
+  max_retry_count,
+  api_base_url,
+  Default_Timeout,
+  user_manager,
+  Calculate_Average,
+  format_user_name,
+  is_valid_email,
+};
+EOF
+
+# Tests
+RUN cat > test_check.js << 'TESTEOF'
+const fs = require('fs');
+const source = fs.readFileSync('utils.js', 'utf8');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// Constants should be UPPER_SNAKE_CASE
+assert(source.includes('MAX_RETRY_COUNT') || source.includes('MAX_RETRIES'), 'max_retry_count -> UPPER_SNAKE_CASE');
+assert(source.includes('API_BASE_URL'), 'api_base_url -> UPPER_SNAKE_CASE');
+assert(source.includes('DEFAULT_TIMEOUT'), 'Default_Timeout -> UPPER_SNAKE_CASE');
+
+// Class should be PascalCase
+assert(source.includes('class UserManager') || source.includes('class UserManager '), 'user_manager -> UserManager');
+
+// Methods should be camelCase
+assert(source.includes('addUser'), 'Add_User -> addUser');
+assert(source.includes('getUserByName'), 'get_user_by_name -> getUserByName');
+assert(source.includes('removeUser'), 'Remove_User -> removeUser');
+assert(source.includes('getActiveUsers'), 'get_Active_Users -> getActiveUsers');
+
+// Functions should be camelCase
+assert(source.includes('calculateAverage'), 'Calculate_Average -> calculateAverage');
+assert(source.includes('formatUserName'), 'format_user_name -> formatUserName');
+assert(source.includes('isValidEmail'), 'is_valid_email -> isValidEmail');
+
+// Variables inside functions should be camelCase
+assert(!source.includes('Total_Sum'), 'Total_Sum -> totalSum');
+assert(!source.includes('New_User'), 'New_User -> newUser');
+assert(!source.includes('Target_Name'), 'Target_Name -> targetName');
+assert(!source.includes('First_Name'), 'First_Name -> firstName');
+assert(!source.includes('user_index'), 'user_index -> userIndex');
+
+// Properties should be camelCase
+assert(!source.includes('User_List'), 'User_List -> userList or users');
+assert(!source.includes('Is_Active'), 'Is_Active -> isActive');
+assert(!source.includes('user_name') || source.match(/user_name/g).length <= 0, 'user_name -> userName or name');
+
+// Module still exports correctly
+try {
+  const mod = require('./utils');
+  assert(typeof mod.calculateAverage === 'function' || typeof mod.Calculate_Average === 'function', 'calculateAverage is exported');
+  assert(typeof mod.formatUserName === 'function' || typeof mod.format_user_name === 'function', 'formatUserName is exported');
+} catch (e) {
+  assert(false, 'Module loads without error: ' + e.message);
+}
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/style_naming/instruction.md
+++ b/tasks/style_naming/instruction.md
@@ -1,0 +1,24 @@
+# Task: Fix Naming Convention Violations
+
+You have a JavaScript module in `utils.js` with inconsistent naming conventions.
+
+## Your Goal
+
+1. Fix all naming convention violations in `utils.js`
+2. Follow standard JavaScript naming conventions:
+   - camelCase for variables and functions
+   - PascalCase for classes
+   - UPPER_SNAKE_CASE for constants
+3. Ensure the module still exports the same functionality
+
+## Requirements
+
+- Rename all identifiers to follow conventions
+- Update ALL references to renamed identifiers
+- Do NOT change the logic or behavior
+- The module must still work correctly after renaming
+
+## Files
+
+- `utils.js` — The module with naming violations (edit this file)
+- `test_check.js` — Tests (do not modify)

--- a/tasks/style_naming/prompts/quality.md
+++ b/tasks/style_naming/prompts/quality.md
@@ -1,0 +1,22 @@
+# Naming Convention Fix Quality Rubric
+
+## Completeness (0–0.5)
+- 0.5: All identifiers follow correct conventions (camelCase, PascalCase, UPPER_SNAKE_CASE)
+- 0.4: Most identifiers fixed (>90%)
+- 0.3: Majority fixed (>70%)
+- 0.2: Some fixed (>50%)
+- 0.1: Few fixed
+- 0.0: None fixed
+
+## Consistency (0–0.3)
+- 0.3: Consistent application of rules across all categories
+- 0.2: Mostly consistent
+- 0.1: Inconsistent
+- 0.0: No pattern
+
+## Correctness (0–0.2)
+- 0.2: All references updated, module works correctly
+- 0.1: Most references updated but some broken
+- 0.0: Module broken after renaming
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/style_naming/skills/style-guide/SKILL.md
+++ b/tasks/style_naming/skills/style-guide/SKILL.md
@@ -1,0 +1,31 @@
+# Style Guide Skill
+
+## Purpose
+Enforce consistent code style and naming conventions.
+
+## Naming Conventions
+- **Variables/Functions**: camelCase (`getUserName`, `totalCount`)
+- **Classes/Components**: PascalCase (`UserProfile`, `DataManager`)
+- **Constants**: UPPER_SNAKE_CASE (`MAX_RETRIES`, `API_BASE_URL`)
+- **Files**: kebab-case (`user-profile.js`, `data-manager.ts`)
+- **Private members**: prefix with underscore (`_internalState`)
+
+## Code Structure
+- Maximum function length: 30 lines
+- Maximum file length: 300 lines
+- One class/component per file
+- Group imports: external → internal → relative
+
+## Formatting
+- 2 spaces for indentation
+- Single quotes for strings
+- Semicolons required
+- Trailing commas in multiline
+- Max line length: 100 characters
+
+## Patterns
+- Prefer `const` over `let`, never use `var`
+- Use template literals over string concatenation
+- Use arrow functions for callbacks
+- Use destructuring where appropriate
+- Use optional chaining (?.) and nullish coalescing (??)

--- a/tasks/style_naming/solution/solve.sh
+++ b/tasks/style_naming/solution/solve.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > utils.js << 'EOF'
+const MAX_RETRY_COUNT = 3;
+const API_BASE_URL = 'https://api.example.com';
+const DEFAULT_TIMEOUT = 5000;
+
+class UserManager {
+  constructor() {
+    this.userList = [];
+    this.activeCount = 0;
+  }
+
+  addUser(userName, userEmail) {
+    const newUser = {
+      userName: userName,
+      userEmail: userEmail,
+      isActive: true,
+    };
+    this.userList.push(newUser);
+    this.activeCount++;
+    return newUser;
+  }
+
+  getUserByName(targetName) {
+    return this.userList.find(u => u.userName === targetName);
+  }
+
+  removeUser(userName) {
+    const userIndex = this.userList.findIndex(u => u.userName === userName);
+    if (userIndex !== -1) {
+      if (this.userList[userIndex].isActive) {
+        this.activeCount--;
+      }
+      this.userList.splice(userIndex, 1);
+      return true;
+    }
+    return false;
+  }
+
+  getActiveUsers() {
+    return this.userList.filter(u => u.isActive);
+  }
+}
+
+function calculateAverage(numberArray) {
+  if (numberArray.length === 0) return 0;
+  const totalSum = numberArray.reduce((acc, val) => acc + val, 0);
+  return totalSum / numberArray.length;
+}
+
+function formatUserName(firstName, lastName) {
+  return `${firstName} ${lastName}`;
+}
+
+const isValidEmail = (emailString) => {
+  return emailString.includes('@') && emailString.includes('.');
+};
+
+module.exports = {
+  MAX_RETRY_COUNT,
+  API_BASE_URL,
+  DEFAULT_TIMEOUT,
+  UserManager,
+  calculateAverage,
+  formatUserName,
+  isValidEmail,
+};
+EOF

--- a/tasks/style_naming/task.toml
+++ b/tasks/style_naming/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "easy"
+category = "style"
+tags = ["style", "naming"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.8
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.2

--- a/tasks/style_naming/tests/test.sh
+++ b/tasks/style_naming/tests/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test_check.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All naming tests pass"
+
+SOURCE=$(cat utils.js)
+
+# No snake_case for non-constants
+check '! echo "$SOURCE" | grep -qP "(?<!_)(function|const|let|var)\s+[a-z]+_[a-z]+" ' "No snake_case function/variable names"
+
+# PascalCase class
+check 'echo "$SOURCE" | grep -q "class UserManager"' "Class is PascalCase"
+
+# UPPER_SNAKE_CASE constants
+check 'echo "$SOURCE" | grep -q "MAX_RETRY_COUNT\|MAX_RETRIES"' "Constants are UPPER_SNAKE_CASE"
+
+# Module still loadable
+check 'node -e "require(\"./utils\")"' "Module loads successfully"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"

--- a/tasks/style_structure/environment/Dockerfile
+++ b/tasks/style_structure/environment/Dockerfile
@@ -1,0 +1,191 @@
+FROM node:20-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
+
+# Poorly structured code
+RUN cat > handler.js << 'EOF'
+function processOrder(order) {
+  if (order) {
+    if (order.items && order.items.length > 0) {
+      let total = 0;
+      let discountedTotal = 0;
+      let errors = [];
+      for (let i = 0; i < order.items.length; i++) {
+        if (order.items[i].price > 0) {
+          if (order.items[i].quantity > 0) {
+            let itemTotal = order.items[i].price * order.items[i].quantity;
+            if (order.items[i].discount) {
+              if (order.items[i].discount > 0 && order.items[i].discount <= 100) {
+                let discountAmount = itemTotal * (order.items[i].discount / 100);
+                itemTotal = itemTotal - discountAmount;
+                discountedTotal += discountAmount;
+              } else {
+                errors.push('Invalid discount for item ' + order.items[i].name);
+              }
+            }
+            total += itemTotal;
+          } else {
+            errors.push('Invalid quantity for item ' + order.items[i].name);
+          }
+        } else {
+          errors.push('Invalid price for item ' + order.items[i].name);
+        }
+      }
+      if (errors.length > 0) {
+        return { success: false, errors: errors };
+      }
+      let tax = 0;
+      if (order.country === 'US') {
+        if (order.state === 'CA') {
+          tax = total * 0.0725;
+        } else if (order.state === 'NY') {
+          tax = total * 0.08;
+        } else {
+          tax = total * 0.05;
+        }
+      } else if (order.country === 'UK') {
+        tax = total * 0.20;
+      } else if (order.country === 'DE') {
+        tax = total * 0.19;
+      } else {
+        tax = total * 0.10;
+      }
+      let shipping = 0;
+      if (total > 100) {
+        shipping = 0;
+      } else if (total > 50) {
+        shipping = 5.99;
+      } else {
+        shipping = 9.99;
+      }
+      if (order.express) {
+        shipping += 15;
+      }
+      return {
+        success: true,
+        subtotal: total,
+        discount: discountedTotal,
+        tax: tax,
+        shipping: shipping,
+        total: total + tax + shipping,
+      };
+    } else {
+      return { success: false, errors: ['No items in order'] };
+    }
+  } else {
+    return { success: false, errors: ['No order provided'] };
+  }
+}
+
+function formatReceipt(orderResult) {
+  if (orderResult) {
+    if (orderResult.success) {
+      let lines = [];
+      lines.push('=== RECEIPT ===');
+      lines.push('Subtotal: $' + orderResult.subtotal.toFixed(2));
+      if (orderResult.discount > 0) {
+        lines.push('Discount: -$' + orderResult.discount.toFixed(2));
+      }
+      lines.push('Tax: $' + orderResult.tax.toFixed(2));
+      if (orderResult.shipping > 0) {
+        lines.push('Shipping: $' + orderResult.shipping.toFixed(2));
+      }
+      lines.push('---');
+      lines.push('Total: $' + orderResult.total.toFixed(2));
+      lines.push('===============');
+      return lines.join('\n');
+    } else {
+      let errorLines = ['=== ERRORS ==='];
+      for (let i = 0; i < orderResult.errors.length; i++) {
+        errorLines.push('- ' + orderResult.errors[i]);
+      }
+      errorLines.push('===============');
+      return errorLines.join('\n');
+    }
+  } else {
+    return 'No result to format';
+  }
+}
+
+module.exports = { processOrder, formatReceipt };
+EOF
+
+# Tests
+RUN cat > test_check.js << 'TESTEOF'
+const fs = require('fs');
+const source = fs.readFileSync('handler.js', 'utf8');
+
+let passed = 0;
+let total = 0;
+
+function assert(condition, msg) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${msg}`); }
+  else { console.log(`  FAIL: ${msg}`); }
+}
+
+// Correctness: processOrder should produce same results
+const { processOrder, formatReceipt } = require('./handler');
+
+const order1 = {
+  items: [{ name: 'A', price: 10, quantity: 2, discount: 10 }, { name: 'B', price: 20, quantity: 1 }],
+  country: 'US', state: 'CA'
+};
+const r1 = processOrder(order1);
+assert(r1.success === true, 'Order 1 succeeds');
+assert(Math.abs(r1.subtotal - 38) < 0.01, 'Order 1 subtotal = 38');
+assert(Math.abs(r1.tax - 2.755) < 0.01, 'Order 1 tax correct');
+assert(r1.shipping === 9.99, 'Order 1 shipping = 9.99');
+
+const r2 = processOrder(null);
+assert(r2.success === false, 'Null order fails');
+
+const r3 = processOrder({ items: [] });
+assert(r3.success === false, 'Empty items fails');
+
+const r4 = processOrder({ items: [{ name: 'X', price: -1, quantity: 1 }], country: 'US', state: 'NY' });
+assert(r4.success === false && r4.errors.length > 0, 'Invalid price caught');
+
+// Formatting
+const receipt = formatReceipt(r1);
+assert(receipt.includes('RECEIPT'), 'Receipt has header');
+assert(receipt.includes('Total: $'), 'Receipt has total');
+
+// Structure checks
+const functions = source.match(/function\s+\w+/g) || [];
+assert(functions.length >= 4, 'At least 4 named functions (code was split)');
+
+// Check nesting depth - count max consecutive indentation
+const lines = source.split('\n');
+let maxIndent = 0;
+for (const line of lines) {
+  const match = line.match(/^(\s*)/);
+  if (match) {
+    const indent = match[1].replace(/\t/g, '  ').length / 2;
+    if (indent > maxIndent) maxIndent = indent;
+  }
+}
+assert(maxIndent <= 5, 'Max nesting depth <= 5 levels');
+
+// Check no single function is too long
+const funcBodies = source.split(/\nfunction |\nconst \w+ = /);
+let maxFuncLength = 0;
+for (const body of funcBodies) {
+  const bodyLines = body.split('\n').filter(l => l.trim() && !l.trim().startsWith('//'));
+  if (bodyLines.length > maxFuncLength) maxFuncLength = bodyLines.length;
+}
+assert(maxFuncLength <= 30, 'No function exceeds 30 lines');
+
+// Exports still work
+assert(typeof processOrder === 'function', 'processOrder exported');
+assert(typeof formatReceipt === 'function', 'formatReceipt exported');
+
+console.log(`\n${passed}/${total} tests passed`);
+process.exit(passed === total ? 0 : 1);
+TESTEOF
+
+RUN mkdir -p logs/verifier
+
+CMD ["bash"]

--- a/tasks/style_structure/instruction.md
+++ b/tasks/style_structure/instruction.md
@@ -1,0 +1,23 @@
+# Task: Improve Code Structure
+
+You have a JavaScript file `handler.js` with poor code structure — overly long functions, deeply nested conditionals, and mixed responsibilities.
+
+## Your Goal
+
+1. Refactor `handler.js` to improve code structure
+2. Break long functions into smaller, focused functions
+3. Reduce nesting by using early returns
+4. Keep the same external API (exported functions)
+
+## Requirements
+
+- No function should exceed 20 lines of logic
+- Maximum nesting depth: 3 levels
+- Each function should have a single responsibility
+- Exported function names and signatures must not change
+- The module must produce identical results
+
+## Files
+
+- `handler.js` — The file to refactor (edit this file)
+- `test_check.js` — Tests (do not modify)

--- a/tasks/style_structure/prompts/quality.md
+++ b/tasks/style_structure/prompts/quality.md
@@ -1,0 +1,22 @@
+# Code Structure Improvement Quality Rubric
+
+## Decomposition (0–0.4)
+- 0.4: Functions properly decomposed, each with single responsibility
+- 0.3: Most logic separated but some mixed concerns remain
+- 0.2: Some extraction but large functions remain
+- 0.1: Minimal extraction
+- 0.0: No structural improvement
+
+## Nesting Reduction (0–0.3)
+- 0.3: Early returns used effectively, max nesting <= 3
+- 0.2: Some nesting reduced
+- 0.1: Minimal nesting reduction
+- 0.0: No nesting changes
+
+## Correctness (0–0.3)
+- 0.3: Refactored code produces identical results
+- 0.2: Mostly correct with minor differences
+- 0.1: Some behavior changes
+- 0.0: Broken after refactoring
+
+Return JSON: {"score": <float 0.0-1.0>, "reasoning": "<explanation>"}

--- a/tasks/style_structure/skills/style-guide/SKILL.md
+++ b/tasks/style_structure/skills/style-guide/SKILL.md
@@ -1,0 +1,31 @@
+# Style Guide Skill
+
+## Purpose
+Enforce consistent code style and naming conventions.
+
+## Naming Conventions
+- **Variables/Functions**: camelCase (`getUserName`, `totalCount`)
+- **Classes/Components**: PascalCase (`UserProfile`, `DataManager`)
+- **Constants**: UPPER_SNAKE_CASE (`MAX_RETRIES`, `API_BASE_URL`)
+- **Files**: kebab-case (`user-profile.js`, `data-manager.ts`)
+- **Private members**: prefix with underscore (`_internalState`)
+
+## Code Structure
+- Maximum function length: 30 lines
+- Maximum file length: 300 lines
+- One class/component per file
+- Group imports: external → internal → relative
+
+## Formatting
+- 2 spaces for indentation
+- Single quotes for strings
+- Semicolons required
+- Trailing commas in multiline
+- Max line length: 100 characters
+
+## Patterns
+- Prefer `const` over `let`, never use `var`
+- Use template literals over string concatenation
+- Use arrow functions for callbacks
+- Use destructuring where appropriate
+- Use optional chaining (?.) and nullish coalescing (??)

--- a/tasks/style_structure/solution/solve.sh
+++ b/tasks/style_structure/solution/solve.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+cat > handler.js << 'EOF'
+function calculateItemTotal(item) {
+  let itemTotal = item.price * item.quantity;
+  if (item.discount) {
+    if (item.discount <= 0 || item.discount > 100) {
+      return { error: 'Invalid discount for item ' + item.name };
+    }
+    const discountAmount = itemTotal * (item.discount / 100);
+    return { total: itemTotal - discountAmount, discount: discountAmount };
+  }
+  return { total: itemTotal, discount: 0 };
+}
+
+function validateItem(item) {
+  if (item.price <= 0) return 'Invalid price for item ' + item.name;
+  if (item.quantity <= 0) return 'Invalid quantity for item ' + item.name;
+  return null;
+}
+
+function calculateTax(total, country, state) {
+  if (country === 'US') {
+    if (state === 'CA') return total * 0.0725;
+    if (state === 'NY') return total * 0.08;
+    return total * 0.05;
+  }
+  if (country === 'UK') return total * 0.20;
+  if (country === 'DE') return total * 0.19;
+  return total * 0.10;
+}
+
+function calculateShipping(total, express) {
+  let shipping = total > 100 ? 0 : total > 50 ? 5.99 : 9.99;
+  if (express) shipping += 15;
+  return shipping;
+}
+
+function processOrder(order) {
+  if (!order) return { success: false, errors: ['No order provided'] };
+  if (!order.items || order.items.length === 0) return { success: false, errors: ['No items in order'] };
+
+  let total = 0;
+  let discountedTotal = 0;
+  const errors = [];
+
+  for (const item of order.items) {
+    const validationError = validateItem(item);
+    if (validationError) { errors.push(validationError); continue; }
+    const result = calculateItemTotal(item);
+    if (result.error) { errors.push(result.error); continue; }
+    total += result.total;
+    discountedTotal += result.discount;
+  }
+
+  if (errors.length > 0) return { success: false, errors };
+
+  const tax = calculateTax(total, order.country, order.state);
+  const shipping = calculateShipping(total, order.express);
+
+  return {
+    success: true,
+    subtotal: total,
+    discount: discountedTotal,
+    tax,
+    shipping,
+    total: total + tax + shipping,
+  };
+}
+
+function formatReceipt(orderResult) {
+  if (!orderResult) return 'No result to format';
+  if (!orderResult.success) return formatErrors(orderResult.errors);
+  return formatSuccess(orderResult);
+}
+
+function formatErrors(errors) {
+  const lines = ['=== ERRORS ==='];
+  for (const error of errors) lines.push('- ' + error);
+  lines.push('===============');
+  return lines.join('\n');
+}
+
+function formatSuccess(result) {
+  const lines = ['=== RECEIPT ==='];
+  lines.push('Subtotal: $' + result.subtotal.toFixed(2));
+  if (result.discount > 0) lines.push('Discount: -$' + result.discount.toFixed(2));
+  lines.push('Tax: $' + result.tax.toFixed(2));
+  if (result.shipping > 0) lines.push('Shipping: $' + result.shipping.toFixed(2));
+  lines.push('---');
+  lines.push('Total: $' + result.total.toFixed(2));
+  lines.push('===============');
+  return lines.join('\n');
+}
+
+module.exports = { processOrder, formatReceipt };
+EOF

--- a/tasks/style_structure/task.toml
+++ b/tasks/style_structure/task.toml
@@ -1,0 +1,27 @@
+version = "1.0"
+
+[metadata]
+author_name = "skill-eval"
+author_email = "eval@skill-eval.dev"
+difficulty = "easy"
+category = "style"
+tags = ["style", "structure"]
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 180.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 500
+
+[[graders]]
+type = "deterministic"
+command = "bash tests/test.sh"
+weight = 0.8
+
+[[graders]]
+type = "llm_rubric"
+rubric = "prompts/quality.md"
+weight = 0.2

--- a/tasks/style_structure/tests/test.sh
+++ b/tasks/style_structure/tests/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -uo pipefail
+
+PASS=0
+TOTAL=0
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$1"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $2"
+  else
+    echo "FAIL: $2"
+  fi
+}
+
+node test_check.js > /tmp/test_output.txt 2>&1; FUNC_EXIT=$?
+cat /tmp/test_output.txt
+check '[ $FUNC_EXIT -eq 0 ]' "All tests pass"
+
+SOURCE=$(cat handler.js)
+
+# Code was split into multiple functions
+FUNC_COUNT=$(echo "$SOURCE" | grep -cE "^(function |const \w+ = \(|const \w+ = function)" || true)
+check '[ "$FUNC_COUNT" -ge 4 ]' "At least 4 function definitions"
+
+# Uses early returns
+EARLY_RETURNS=$(echo "$SOURCE" | grep -c "return.*error\|return.*false\|return.*null" || true)
+check '[ "$EARLY_RETURNS" -ge 2 ]' "Uses early returns"
+
+# Module loads
+check 'node -e "const m = require(\"./handler\"); m.processOrder({items:[{name:\"x\",price:10,quantity:1}],country:\"US\",state:\"CA\"})"' "Module works correctly"
+
+mkdir -p logs/verifier
+if [ $TOTAL -gt 0 ]; then
+  SCORE=$(echo "scale=2; $PASS / $TOTAL" | bc)
+else
+  SCORE="0.00"
+fi
+echo "$SCORE" > logs/verifier/reward.txt
+echo "Score: $PASS/$TOTAL = $SCORE"


### PR DESCRIPTION
## Summary
- Add 12 eval tasks covering 4 agent skill categories: security (SQLi, XSS, path traversal), performance (algorithm, N+1 queries, React re-renders), style (naming, structure, formatting), and bug detection (off-by-one, null reference, race conditions)
- Add 5 suite definitions for grouped testing: `security`, `performance`, `style`, `bug-detection`, `all-skills`
- Each task includes Dockerfile, deterministic tests with partial scoring, LLM rubric, reference solution, and co-located skill files

## Test plan
- [ ] Run `npm run validate <task>` for each of the 12 tasks to verify reference solutions pass graders
- [ ] Run `npm run eval --suite=security --trials=3 --no-skills` for baseline measurement
- [ ] Run `npm run eval --suite=security --trials=3` with skills to verify normalized gain
- [ ] Run `npm run eval --suite=all-skills --trials=1` for coexistence smoke test
- [ ] Verify partial scoring works (inject a partial solution and check `logs/verifier/reward.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)