### PR TITLE
fix: use correct Claude Code CLI flags

### DIFF
--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -10,7 +10,7 @@ export class ClaudeAgent extends BaseAgent {
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
-        const command = `claude "$(cat /tmp/.prompt.md)" --yes --no-auto-update`;
+        const command = `claude -p --dangerously-skip-permissions "$(cat /tmp/.prompt.md)"`;
         const result = await runCommand(command);
 
         if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary

- Replace `--yes --no-auto-update` with `-p --dangerously-skip-permissions` in `ClaudeAgent`
- `--yes` and `--no-auto-update` are not valid Claude Code CLI options, causing every trial to fail immediately with exit code 1

The correct flags are:
- `-p` (`--print`): non-interactive mode — prints response and exits, required for piped/scripted usage
- `--dangerously-skip-permissions`: bypasses permission prompts (equivalent to Gemini's `-y` and Codex's `--approval-mode full-auto`)

## Reproduction

```bash
ANTHROPIC_API_KEY=your-key skillgrade --smoke --agent=claude
```

Every trial fails in <1s with:
```
error: unknown option '--yes'
```

## Verified

Tested locally with `--provider=local` — Claude agent now correctly executes and produces graded results.

Fixes #7