### PR TITLE
Support running agent from a directory other than /workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 *.json
 !package.json
 !tsconfig.json
+!tsconfig.build.json
 logs/
 coverage/
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ tasks:
         dest: /usr/local/bin/superlint
         chmod: "+x"
 
+    trialConfig:                         # per-trial hooks (optional)
+      setup: "echo setup"                # inline or file path
+      cleanup: "echo cleanup"            # inline or file path
+
     graders:
       - type: deterministic
         setup: npm install typescript    # grader-specific deps (optional)
@@ -119,11 +123,14 @@ tasks:
     timeout: 600
 ```
 
-String values (`instruction`, `rubric`, `run`) support **file references** — if the value is a valid file path, its contents are read automatically:
+String values (`instruction`, `rubric`, `run`) and `trialConfig` fields (`setup`, `cleanup`) support **file references** — if the value is a valid file path, its contents are read automatically:
 
 ```yaml
 instruction: instructions/fix-linting.md
 rubric: rubrics/workflow-quality.md
+trialConfig:
+  setup: scripts/setup.sh
+  cleanup: scripts/cleanup.sh
 ```
 
 ## Graders

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [examples/](examples/) — [superlint](examples/superlint/) (simple) and [an
 **Prerequisites**: Node.js 20+, Docker
 
 ```bash
-npm i -g skillgrade
+npm i -g @kmonty/skillgrade
 ```
 
 **1. Initialize** — go to your skill directory (must have `SKILL.md`) and scaffold:
@@ -213,7 +213,7 @@ Use `--provider=local` in CI — the runner is already an ephemeral sandbox, so 
 ```yaml
 # .github/workflows/skillgrade.yml
 - run: |
-    npm i -g skillgrade
+    npm i -g @kmonty/skillgrade
     cd skills/superlint
     GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} skillgrade --regression --ci --provider=local
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ tasks:
       - src: bin/superlint
         dest: /usr/local/bin/superlint
         chmod: "+x"
+      - content: |                       # inline file content
+          # Gemini Custom Instructions
+          Always use TypeScript for new files.
+        dest: /root/.gemini/GEMINI.md
 
     trialConfig:                         # per-trial hooks (optional)
       setup: "echo setup"                # inline or file path
@@ -133,6 +137,20 @@ rubric: rubrics/workflow-quality.md
 trialConfig:
   setup: scripts/setup.sh
   cleanup: scripts/cleanup.sh
+```
+
+### Workspace Inline Content
+
+For `workspace` mappings, you can use the `content` field instead of `src` to provide the file content directly in `eval.yaml`. This is useful for small configuration files or scripts. It writes the content to a file in a `workspace_files/` subdirectory within the build context and uses standard `COPY` under the hood.
+
+```yaml
+workspace:
+  - content: |
+      # Custom Instructions for Gemini
+      
+      - Use standard style.
+      - Write tests for all new features.
+    dest: /root/.gemini/GEMINI.md
 ```
 
 ### Docker Bind Mounts

--- a/README.md
+++ b/README.md
@@ -247,13 +247,54 @@ Exits with code 1 if pass rate falls below `--threshold` (default: 0.8).
 
 ## Environment Variables
 
+### Core Variables
+
 | Variable | Used by |
 |----------|---------|
 | `GEMINI_API_KEY` | Agent execution, LLM grading, `skillgrade init` |
 | `ANTHROPIC_API_KEY` | Agent execution, LLM grading, `skillgrade init` |
 | `OPENAI_API_KEY` | Agent execution (Codex), `skillgrade init` |
 
-Variables are also loaded from `.env` in the skill directory. Shell values override `.env`. All values are **redacted** from persisted session logs.
+### Configuration and Precedence
+
+You can define custom environment variables at multiple levels to customize the execution environment for your tasks.
+
+#### Supported Locations
+
+- **`defaults` in `eval.yaml`**: Sets environment variables for all tasks in the file.
+- **`tasks` in `eval.yaml`**: Sets environment variables for a specific task, overriding defaults.
+- **`trialConfig` in `eval.yaml`**: Sets environment variables for a specific trial, overriding task and default settings.
+- **`.env` file**: Located in the skill directory. These are loaded as base environment variables.
+
+#### Precedence Order
+
+Variables are merged in the following order (highest priority wins):
+
+1. **Trial Level**: `trialConfig.env` in `eval.yaml`
+2. **Task Level**: `env` in `eval.yaml` task definition
+3. **Defaults Level**: `defaults.env` in `eval.yaml`
+4. **`.env` File**: Variables defined in `.env` file.
+5. **System Environment**: Variables set in your shell. (Note: Only specific API keys like `GEMINI_API_KEY` are automatically passed through to the execution environment by default, unless using the `local` provider where all system variables are visible).
+
+#### Example
+
+```yaml
+defaults:
+  env:
+    GLOBAL_VAR: "global_value"
+
+tasks:
+  - name: test-task
+    env:
+      TASK_VAR: "task_value"
+      GLOBAL_VAR: "overridden_by_task"
+    trialConfig:
+      env:
+        TRIAL_VAR: "trial_value"
+        TASK_VAR: "overridden_by_trial"
+```
+
+All environment variables (including those from `.env` and `eval.yaml`) are **redacted** from persisted session logs by default.
 
 ## Best Practices
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ defaults:
   environment:           # container resource limits
     cpus: 2
     memory_mb: 2048
+    mounts:              # bind mounts (Docker only)
+      - /host/path:/container/path
 
 tasks:
   - name: fix-linting-errors
@@ -131,6 +133,17 @@ rubric: rubrics/workflow-quality.md
 trialConfig:
   setup: scripts/setup.sh
   cleanup: scripts/cleanup.sh
+```
+
+### Docker Bind Mounts
+
+You can mount directories or files from your host machine into the Docker container by specifying `mounts` in the `environment` section (either in `defaults` or per-task).
+
+```yaml
+environment:
+  mounts:
+    - /host/path:/container/path
+    - ~/data:/data # Supports ~ expansion for home directory
 ```
 
 ## Graders

--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ Evaluates the agent's session transcript against qualitative criteria:
 
 Uses Gemini or Anthropic based on available API key. Override with the `model` field.
 
+### Tool Usage
+
+Verifies that the agent called specific tools during the trial, optionally validating arguments:
+
+```yaml
+- type: tool_usage
+  expectedTools:
+    - name: read_file # Arguments are optional
+    - name: write_to_file
+      args:
+        path: test.txt # Verifies arguments too
+  weight: 0.5
+```
+
+This grader parses the execution logs to check if the specified tools were invoked. It is useful for enforcing specific workflows or ensuring the agent uses required skills. Argument validation performs a subset match, ensuring the expected arguments are present in the actual call.
+
 ### Combining Graders
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -274,12 +274,12 @@ You can define custom environment variables at multiple levels to customize the 
 
 #### Supported Locations
 
-- **`defaults` in `eval.yaml`**: Sets environment variables for all tasks in the file.
-- **`tasks` in `eval.yaml`**: Sets environment variables for a specific task, overriding defaults.
-- **`trialConfig` in `eval.yaml`**: Sets environment variables for a specific trial, overriding task and default settings.
+- **`defaults` in `eval.yaml`**: Sets base configuration (environment variables, `trialConfig`, etc.) for all tasks.
+- **`tasks` in `eval.yaml`**: Sets configuration for a specific task, overriding defaults.
+- **`trialConfig` in `eval.yaml`**: Sets hooks and environment variables for a specific trial. Can be defined in `defaults` and overridden or merged at the task level.
 - **`.env` file**: Located in the skill directory. These are loaded as base environment variables.
 
-#### Precedence Order
+#### Precedence Order for Environment Variables
 
 Variables are merged in the following order (highest priority wins):
 
@@ -306,6 +306,12 @@ tasks:
         TRIAL_VAR: "trial_value"
         TASK_VAR: "overridden_by_trial"
 ```
+
+### trialConfig Merging
+
+When `trialConfig` is specified in both `defaults` and a specific task:
+- `env` objects are merged (task overrides defaults).
+- `setup` and `cleanup` scripts are **concatenated** with a newline (default script runs first, followed by task script).
 
 All environment variables (including those from `.env` and `eval.yaml`) are **redacted** from persisted session logs by default.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The easiest way to evaluate your Agent Skills — test that AI agents correctly discover and use your skills",
   "main": "dist/skillgrade.js",
   "types": "dist/skillgrade.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "skillgrade",
-  "version": "0.1.3",
+  "name": "@kmonty/skillgrade",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "0.1.0",
   "description": "The easiest way to evaluate your Agent Skills — test that AI agents correctly discover and use your skills",
   "main": "dist/skillgrade.js",
   "types": "dist/skillgrade.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The easiest way to evaluate your Agent Skills — test that AI agents correctly discover and use your skills",
   "main": "dist/skillgrade.js",
   "types": "dist/skillgrade.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The easiest way to evaluate your Agent Skills — test that AI agents correctly discover and use your skills",
   "main": "dist/skillgrade.js",
   "types": "dist/skillgrade.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The easiest way to evaluate your Agent Skills — test that AI agents correctly discover and use your skills",
   "main": "dist/skillgrade.js",
   "types": "dist/skillgrade.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The easiest way to evaluate your Agent Skills — test that AI agents correctly discover and use your skills",
   "main": "dist/skillgrade.js",
   "types": "dist/skillgrade.d.ts",

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -4,14 +4,16 @@ export class ClaudeAgent extends BaseAgent {
     async run(
         instruction: string,
         _workspacePath: string,
-        runCommand: (cmd: string) => Promise<CommandResult>
+        runCommand: (cmd: string) => Promise<CommandResult>,
+        options?: { agentWorkingDir?: string }
     ): Promise<string> {
         // Write instruction to a temp file to avoid shell escaping issues with long prompts
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
         const command = `claude -p --dangerously-skip-permissions "$(cat /tmp/.prompt.md)"`;
-        const result = await runCommand(command);
+        const fullCommand = options?.agentWorkingDir ? `cd ${options.agentWorkingDir} && ${command}` : command;
+        const result = await runCommand(fullCommand);
 
         if (result.exitCode !== 0) {
             console.error('ClaudeAgent: Claude failed to execute correctly.');

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -4,14 +4,16 @@ export class CodexAgent extends BaseAgent {
     async run(
         instruction: string,
         _workspacePath: string,
-        runCommand: (cmd: string) => Promise<CommandResult>
+        runCommand: (cmd: string) => Promise<CommandResult>,
+        options?: { agentWorkingDir?: string }
     ): Promise<string> {
         // Write instruction to a temp file to avoid shell escaping issues with long prompts
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
         const command = `codex --approval-mode full-auto "$(cat /tmp/.prompt.md)"`;
-        const result = await runCommand(command);
+        const fullCommand = options?.agentWorkingDir ? `cd ${options.agentWorkingDir} && ${command}` : command;
+        const result = await runCommand(fullCommand);
 
         if (result.exitCode !== 0) {
             console.error('CodexAgent: Codex CLI failed to execute correctly.');

--- a/src/agents/gemini.ts
+++ b/src/agents/gemini.ts
@@ -4,14 +4,16 @@ export class GeminiAgent extends BaseAgent {
     async run(
         instruction: string,
         _workspacePath: string,
-        runCommand: (cmd: string) => Promise<CommandResult>
+        runCommand: (cmd: string) => Promise<CommandResult>,
+        options?: { agentWorkingDir?: string }
     ): Promise<string> {
         // Write instruction to a temp file to avoid shell escaping issues with long prompts
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
         const command = `gemini -y --sandbox=none --output-format stream-json -p "$(cat /tmp/.prompt.md)"`;
-        const result = await runCommand(command);
+        const fullCommand = options?.agentWorkingDir ? `cd ${options.agentWorkingDir} && ${command}` : command;
+        const result = await runCommand(fullCommand);
 
         const lines = result.stdout.split('\n');
         const toolCalls: string[] = [];

--- a/src/agents/gemini.ts
+++ b/src/agents/gemini.ts
@@ -10,13 +10,41 @@ export class GeminiAgent extends BaseAgent {
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
-        const command = `gemini -y --sandbox=none -p "$(cat /tmp/.prompt.md)"`;
+        const command = `gemini -y --sandbox=none --output-format stream-json -p "$(cat /tmp/.prompt.md)"`;
         const result = await runCommand(command);
+
+        const lines = result.stdout.split('\n');
+        const toolCalls: string[] = [];
+        let finalResponse = '';
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+                const event = JSON.parse(trimmed);
+                if (event.type === 'tool_use') {
+                    toolCalls.push(trimmed);
+                } else if (event.type === 'message') {
+                    finalResponse += event.content || event.text || '';
+                } else if (event.type === 'result') {
+                    finalResponse = event.response || finalResponse;
+                }
+            } catch (e) {
+                // Ignore parse errors
+            }
+        }
+
+        // Write tool calls to file
+        if (toolCalls.length > 0) {
+            const toolCallsContent = toolCalls.join('\n');
+            const b64Tools = Buffer.from(toolCallsContent).toString('base64');
+            await runCommand(`echo '${b64Tools}' | base64 -d > .tool_calls.log`);
+        }
 
         if (result.exitCode !== 0) {
             console.error('GeminiAgent: Gemini CLI failed to execute correctly.');
         }
 
-        return result.stdout + '\n' + result.stderr;
+        return finalResponse || (result.stdout + (result.stderr ? '\n' + result.stderr : ''));
     }
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -121,7 +121,10 @@ export async function runEvals(dir: string, opts: RunOptions) {
             timeoutSec: resolved.timeout,
             graderModel: resolved.grader_model,
             environment: resolved.environment,
-            trialSetup: resolved.trialSetup,
+            trialConfig: {
+                setup: resolved.trialConfig?.setup ? 'bash scripts/trial_setup.sh' : undefined,
+                cleanup: resolved.trialConfig?.cleanup ? 'bash scripts/trial_cleanup.sh' : undefined,
+            },
         };
 
         // Pick agent: CLI flag > task-level override > auto-detect from API key > default
@@ -259,6 +262,29 @@ async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string, tmpDi
         if (llmGraders[i].rubric) {
             const filename = i === 0 ? 'quality.md' : `quality_${i}.md`;
             await fs.writeFile(path.join(tmpDir, 'prompts', filename), llmGraders[i].rubric!);
+        }
+    }
+
+    // Write trial setup and cleanup scripts
+    if (resolved.trialConfig) {
+        await fs.ensureDir(path.join(tmpDir, 'scripts'));
+        
+        const ensureShebang = (content: string) => {
+            if (content.startsWith('#!')) return content;
+            return `#!/bin/bash\n\n${content}`;
+        };
+
+        if (resolved.trialConfig.setup) {
+            await fs.writeFile(
+                path.join(tmpDir, 'scripts', 'trial_setup.sh'),
+                ensureShebang(resolved.trialConfig.setup.trim())
+            );
+        }
+        if (resolved.trialConfig.cleanup) {
+            await fs.writeFile(
+                path.join(tmpDir, 'scripts', 'trial_cleanup.sh'),
+                ensureShebang(resolved.trialConfig.cleanup.trim())
+            );
         }
     }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -130,6 +130,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
                 cleanup: resolved.trialConfig?.cleanup ? 'bash scripts/trial_cleanup.sh' : undefined,
                 env: resolved.trialConfig?.env,
             },
+            agentWorkingDir: resolved.agentWorkingDir,
         };
 
         // Pick agent: CLI flag > task-level override > auto-detect from API key > default

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -121,6 +121,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             timeoutSec: resolved.timeout,
             graderModel: resolved.grader_model,
             environment: resolved.environment,
+            trialSetup: resolved.trialSetup,
         };
 
         // Pick agent: CLI flag > task-level override > auto-detect from API key > default

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -231,7 +231,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
  * Contains: Dockerfile, workspace files, grader scripts.
  * No longer writes task.toml or instruction.md — those are passed directly.
  */
-async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string, tmpDir: string) {
+export async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string, tmpDir: string) {
     await fs.ensureDir(tmpDir);
 
     // Write each deterministic grader script
@@ -273,7 +273,7 @@ async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string, tmpDi
     // Write trial setup and cleanup scripts
     if (resolved.trialConfig) {
         await fs.ensureDir(path.join(tmpDir, 'scripts'));
-        
+
         const ensureShebang = (content: string) => {
             if (content.startsWith('#!')) return content;
             return `#!/bin/bash\n\n${content}`;
@@ -318,15 +318,31 @@ async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string, tmpDi
         }
     }
 
+    let inlineFileCount = 0;
+    const workspaceFilesDir = path.join(tmpDir, 'workspace_files');
     // Copy workspace files
     for (const w of resolved.workspace) {
-        const srcPath = path.resolve(baseDir, w.src);
-        const destInTmp = path.join(tmpDir, path.basename(w.src));
-        if (await fs.pathExists(srcPath)) {
-            await fs.copy(srcPath, destInTmp);
-            dockerfileContent += `COPY ${path.basename(w.src)} ${w.dest}\n`;
+        if (w.content !== undefined) {
+            inlineFileCount++;
+            await fs.ensureDir(workspaceFilesDir);
+            const tmpFileName = `inline_file_${inlineFileCount}.tmp`;
+            await fs.writeFile(path.join(workspaceFilesDir, tmpFileName), w.content);
+
+            dockerfileContent += `COPY workspace_files/${tmpFileName} ${w.dest}\n`;
             if (w.chmod) {
                 dockerfileContent += `RUN chmod ${w.chmod} ${w.dest}\n`;
+            }
+        } else if (w.src) {
+            const srcPath = path.resolve(baseDir, w.src);
+            const destInTmp = path.join(tmpDir, path.basename(w.src));
+            if (await fs.pathExists(srcPath)) {
+                await fs.copy(srcPath, destInTmp);
+                dockerfileContent += `COPY ${path.basename(w.src)} ${w.dest}\n`;
+                if (w.chmod) {
+                    dockerfileContent += `RUN chmod ${w.chmod} ${w.dest}\n`;
+                }
+            } else {
+                throw new Error(`Workspace file not found: ${srcPath}`);
             }
         }
     }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -29,6 +29,7 @@ interface RunOptions {
     provider?: string;   // override provider (docker|local)
     output?: string;     // output directory for reports and temp files
     grader?: string;     // filter graders by type (deterministic|llm_rubric)
+    noRedact?: boolean;
 }
 
 async function loadEnvFile(filePath: string): Promise<Record<string, string>> {
@@ -143,7 +144,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             ? new DockerProvider()
             : new LocalProvider();
 
-        const runner = new EvalRunner(provider, resultsDir);
+        const runner = new EvalRunner(provider, resultsDir, opts.noRedact);
 
         if (opts.validate) {
             // Validation mode

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -105,6 +105,10 @@ export async function runEvals(dir: string, opts: RunOptions) {
     // Run each task
     for (const taskDef of tasksToRun) {
         const resolved = await resolveTask(taskDef, config.defaults, dir);
+        const mergedEnv = {
+            ...env,
+            ...resolved.env,
+        };
         const trials = opts.trials ?? resolved.trials;
         const parallel = opts.parallel ?? 1;
 
@@ -124,6 +128,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             trialConfig: {
                 setup: resolved.trialConfig?.setup ? 'bash scripts/trial_setup.sh' : undefined,
                 cleanup: resolved.trialConfig?.cleanup ? 'bash scripts/trial_cleanup.sh' : undefined,
+                env: resolved.trialConfig?.env,
             },
         };
 
@@ -166,7 +171,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
                 }
             } as BaseAgent;
 
-            const report = await runner.runEval(solveAgent, tmpTaskDir, skillsPaths, evalOpts, 1, env);
+            const report = await runner.runEval(solveAgent, tmpTaskDir, skillsPaths, evalOpts, 1, mergedEnv);
             const passed = report.trials[0].reward >= 0.5;
 
             validationResult(passed, report.trials[0].reward, report.trials[0].grader_results.map(gr => ({
@@ -185,7 +190,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             console.log();
 
             try {
-                const report = await runner.runEval(agent, tmpTaskDir, skillsPaths, evalOpts, trials, env, parallel);
+                const report = await runner.runEval(agent, tmpTaskDir, skillsPaths, evalOpts, trials, mergedEnv, parallel);
                 reports.push(report);
 
                 // LLM grader reasoning (condensed)

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -130,6 +130,10 @@ function validateConfig(raw: any): EvalConfig {
 
         validateTrialConfig(t.trialConfig, `Task "${t.name}" trialConfig`);
 
+        if (t.agentWorkingDir && typeof t.agentWorkingDir !== 'string') {
+            throw new Error(`Task "${t.name}" agentWorkingDir must be a string`);
+        }
+
         const workspace: WorkspaceMapping[] = (t.workspace || []).map((w: any) => {
             if (typeof w === 'string') {
                 // Support shorthand: "fixtures/app.js" → same filename in workspace
@@ -183,6 +187,7 @@ function validateConfig(raw: any): EvalConfig {
             trialConfig: t.trialConfig,
             env: t.env,
             environment: t.environment,
+            agentWorkingDir: t.agentWorkingDir,
         };
     });
 
@@ -301,6 +306,7 @@ export async function resolveTask(
         environment,
         env,
         trialConfig,
+        agentWorkingDir: task.agentWorkingDir,
     };
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -116,7 +116,7 @@ function validateConfig(raw: any): EvalConfig {
             trials: t.trials,
             timeout: t.timeout,
             docker: t.docker,
-            trialSetup: t.trialSetup,
+            trialConfig: t.trialConfig,
         };
     });
 
@@ -186,7 +186,10 @@ export async function resolveTask(
         grader_model,
         docker,
         environment,
-        trialSetup: task.trialSetup,
+        trialConfig: task.trialConfig ? {
+            setup: task.trialConfig.setup ? await resolveFileOrInline(task.trialConfig.setup, baseDir) : undefined,
+            cleanup: task.trialConfig.cleanup ? await resolveFileOrInline(task.trialConfig.cleanup, baseDir) : undefined,
+        } : undefined,
     };
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -135,10 +135,16 @@ function validateConfig(raw: any): EvalConfig {
                 // Support shorthand: "fixtures/app.js" → same filename in workspace
                 return { src: w, dest: path.basename(w) };
             }
-            if (!w.src || !w.dest) {
-                throw new Error(`Task "${t.name}" has a workspace mapping without src/dest`);
+            if (!w.dest) {
+                throw new Error(`Task "${t.name}" has a workspace mapping without dest`);
             }
-            return { src: w.src, dest: w.dest, chmod: w.chmod };
+            if (!w.src && w.content === undefined) {
+                throw new Error(`Task "${t.name}" has a workspace mapping without src or content`);
+            }
+            if (w.src && w.content !== undefined) {
+                throw new Error(`Task "${t.name}" has a workspace mapping with both src and content`);
+            }
+            return { src: w.src, content: w.content, dest: w.dest, chmod: w.chmod };
         });
 
         return {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -116,6 +116,7 @@ function validateConfig(raw: any): EvalConfig {
             trials: t.trials,
             timeout: t.timeout,
             docker: t.docker,
+            trialSetup: t.trialSetup,
         };
     });
 
@@ -185,6 +186,7 @@ export async function resolveTask(
         grader_model,
         docker,
         environment,
+        trialSetup: task.trialSetup,
     };
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -102,14 +102,29 @@ function validateConfig(raw: any): EvalConfig {
             name: t.name,
             instruction: t.instruction,
             workspace,
-            graders: t.graders.map((g: any) => ({
-                type: g.type,
-                setup: g.setup,
-                run: g.run,
-                rubric: g.rubric,
-                model: g.model,
-                weight: g.weight ?? 1.0,
-            })),
+            graders: t.graders.map((g: any) => {
+                if (g.type === 'tool_usage') {
+                    if (g.expectedTools) {
+                        if (!Array.isArray(g.expectedTools)) {
+                            throw new Error(`Task "${t.name}" has invalid expectedTools: must be an array`);
+                        }
+                        for (const et of g.expectedTools) {
+                            if (typeof et !== 'object' || !et.name) {
+                                throw new Error(`Task "${t.name}" has invalid expectedTool: must be an object with a "name" property`);
+                            }
+                        }
+                    }
+                }
+                return {
+                    type: g.type,
+                    setup: g.setup,
+                    run: g.run,
+                    rubric: g.rubric,
+                    model: g.model,
+                    weight: g.weight ?? 1.0,
+                    expectedTools: g.expectedTools,
+                };
+            }),
             solution: t.solution,
             agent: t.agent,
             provider: t.provider,
@@ -157,6 +172,7 @@ export async function resolveTask(
                 setup: g.setup,
                 model: g.model,
                 weight: g.weight,
+                expectedTools: g.expectedTools,
             };
             if (g.type === 'deterministic' && g.run) {
                 resolved.run = await resolveFileOrInline(g.run, baseDir);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,6 +3,7 @@
  */
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as os from 'os';
 import {
     EvalConfig,
     EvalDefaults,
@@ -54,6 +55,19 @@ export async function loadEvalConfig(dir: string): Promise<EvalConfig> {
     return validateConfig(raw);
 }
 
+function validateMounts(mounts: any, context: string) {
+    if (mounts) {
+        if (!Array.isArray(mounts)) {
+            throw new Error(`${context} must be an array`);
+        }
+        for (const m of mounts) {
+            if (typeof m !== 'string') {
+                throw new Error(`${context} must be an array of strings`);
+            }
+        }
+    }
+}
+
 /**
  * Validate raw parsed YAML into a typed EvalConfig.
  */
@@ -77,6 +91,8 @@ function validateConfig(raw: any): EvalConfig {
         env: raw.defaults?.env,
     };
 
+    validateMounts(defaults.environment.mounts, 'defaults.environment.mounts');
+
     if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
         throw new Error('eval.yaml must have at least one task in the "tasks" array');
     }
@@ -86,6 +102,10 @@ function validateConfig(raw: any): EvalConfig {
         if (!t.instruction) throw new Error(`Task "${t.name}" is missing an "instruction"`);
         if (!t.graders || !Array.isArray(t.graders) || t.graders.length === 0) {
             throw new Error(`Task "${t.name}" must have at least one grader`);
+        }
+
+        if (t.environment) {
+            validateMounts(t.environment.mounts, `Task "${t.name}" environment.mounts`);
         }
 
         const workspace: WorkspaceMapping[] = (t.workspace || []).map((w: any) => {
@@ -134,6 +154,7 @@ function validateConfig(raw: any): EvalConfig {
             docker: t.docker,
             trialConfig: t.trialConfig,
             env: t.env,
+            environment: t.environment,
         };
     });
 
@@ -161,6 +182,16 @@ export async function resolveTask(
         ...defaults.environment,
         ...(task.environment || {}),
     };
+
+    if (environment.mounts) {
+        environment.mounts = environment.mounts.map(m => {
+            if (m.startsWith('~')) {
+                return os.homedir() + m.slice(1);
+            }
+            return m;
+        });
+    }
+
     const grader_model = task.grader_model || defaults.grader_model;
     const env = {
         ...defaults.env,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -74,6 +74,7 @@ function validateConfig(raw: any): EvalConfig {
             ...DEFAULT_CONFIG.environment,
             ...(raw.defaults?.environment || {}),
         },
+        env: raw.defaults?.env,
     };
 
     if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
@@ -132,6 +133,7 @@ function validateConfig(raw: any): EvalConfig {
             timeout: t.timeout,
             docker: t.docker,
             trialConfig: t.trialConfig,
+            env: t.env,
         };
     });
 
@@ -160,6 +162,10 @@ export async function resolveTask(
         ...(task.environment || {}),
     };
     const grader_model = task.grader_model || defaults.grader_model;
+    const env = {
+        ...defaults.env,
+        ...task.env,
+    };
 
     // Resolve instruction — could be inline text or file path
     const instruction = await resolveFileOrInline(task.instruction, baseDir);
@@ -202,9 +208,11 @@ export async function resolveTask(
         grader_model,
         docker,
         environment,
+        env,
         trialConfig: task.trialConfig ? {
             setup: task.trialConfig.setup ? await resolveFileOrInline(task.trialConfig.setup, baseDir) : undefined,
             cleanup: task.trialConfig.cleanup ? await resolveFileOrInline(task.trialConfig.cleanup, baseDir) : undefined,
+            env: task.trialConfig.env,
         } : undefined,
     };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -12,6 +12,7 @@ import {
     ResolvedGrader,
     WorkspaceMapping,
     EnvironmentConfig,
+    TrialConfig,
 } from './config.types';
 
 // We use a simple YAML parser — js-yaml is the standard
@@ -68,6 +69,23 @@ function validateMounts(mounts: any, context: string) {
     }
 }
 
+function validateTrialConfig(tc: any, context: string) {
+    if (tc) {
+        if (typeof tc !== 'object') {
+            throw new Error(`${context} must be an object`);
+        }
+        if (tc.setup && typeof tc.setup !== 'string') {
+            throw new Error(`${context}.setup must be a string`);
+        }
+        if (tc.cleanup && typeof tc.cleanup !== 'string') {
+            throw new Error(`${context}.cleanup must be a string`);
+        }
+        if (tc.env && typeof tc.env !== 'object') {
+            throw new Error(`${context}.env must be an object`);
+        }
+    }
+}
+
 /**
  * Validate raw parsed YAML into a typed EvalConfig.
  */
@@ -89,9 +107,11 @@ function validateConfig(raw: any): EvalConfig {
             ...(raw.defaults?.environment || {}),
         },
         env: raw.defaults?.env,
+        trialConfig: raw.defaults?.trialConfig,
     };
 
     validateMounts(defaults.environment.mounts, 'defaults.environment.mounts');
+    validateTrialConfig(defaults.trialConfig, 'defaults.trialConfig');
 
     if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
         throw new Error('eval.yaml must have at least one task in the "tasks" array');
@@ -107,6 +127,8 @@ function validateConfig(raw: any): EvalConfig {
         if (t.environment) {
             validateMounts(t.environment.mounts, `Task "${t.name}" environment.mounts`);
         }
+
+        validateTrialConfig(t.trialConfig, `Task "${t.name}" trialConfig`);
 
         const workspace: WorkspaceMapping[] = (t.workspace || []).map((w: any) => {
             if (typeof w === 'string') {
@@ -226,6 +248,38 @@ export async function resolveTask(
         ? path.resolve(baseDir, task.solution)
         : undefined;
 
+    // Merge trialConfig
+    const defaultTC = defaults.trialConfig;
+    const taskTC = task.trialConfig;
+    let trialConfig: TrialConfig | undefined = undefined;
+
+    if (defaultTC || taskTC) {
+        const env = {
+            ...defaultTC?.env,
+            ...taskTC?.env,
+        };
+
+        const setupParts = [];
+        if (defaultTC?.setup) setupParts.push(await resolveFileOrInline(defaultTC.setup, baseDir));
+        if (taskTC?.setup) setupParts.push(await resolveFileOrInline(taskTC.setup, baseDir));
+
+        const cleanupParts = [];
+        if (defaultTC?.cleanup) cleanupParts.push(await resolveFileOrInline(defaultTC.cleanup, baseDir));
+        if (taskTC?.cleanup) cleanupParts.push(await resolveFileOrInline(taskTC.cleanup, baseDir));
+
+        const mergedEnv = Object.keys(env).length > 0 ? env : undefined;
+        const mergedSetup = setupParts.length > 0 ? setupParts.join('\n') : undefined;
+        const mergedCleanup = cleanupParts.length > 0 ? cleanupParts.join('\n') : undefined;
+
+        if (mergedEnv || mergedSetup || mergedCleanup) {
+            trialConfig = {
+                env: mergedEnv,
+                setup: mergedSetup,
+                cleanup: mergedCleanup,
+            };
+        }
+    }
+
     return {
         name: task.name,
         instruction,
@@ -240,11 +294,7 @@ export async function resolveTask(
         docker,
         environment,
         env,
-        trialConfig: task.trialConfig ? {
-            setup: task.trialConfig.setup ? await resolveFileOrInline(task.trialConfig.setup, baseDir) : undefined,
-            cleanup: task.trialConfig.cleanup ? await resolveFileOrInline(task.trialConfig.cleanup, baseDir) : undefined,
-            env: task.trialConfig.env,
-        } : undefined,
+        trialConfig,
     };
 }
 

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -9,7 +9,8 @@ import { ExpectedTool } from '../types';
 
 /** Workspace file mapping: copy a local file into the container */
 export interface WorkspaceMapping {
-    src: string;        // relative to eval.yaml
+    src?: string;       // relative to eval.yaml
+    content?: string;   // inline content
     dest: string;       // path in container (relative = in /workspace, absolute = absolute)
     chmod?: string;     // e.g. "+x"
 }

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -63,6 +63,7 @@ export interface EvalTaskConfig {
     grader_model?: string;
     docker?: DockerConfig;
     environment?: Partial<EnvironmentConfig>;
+    agentWorkingDir?: string;
 }
 
 /** Top-level defaults */
@@ -103,6 +104,7 @@ export interface ResolvedTask {
     docker: DockerConfig;
     environment: EnvironmentConfig;
     env?: Record<string, string>;
+    agentWorkingDir?: string;
 }
 
 export interface ResolvedGrader {

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -41,6 +41,7 @@ export interface EvalTaskConfig {
     workspace?: WorkspaceMapping[];
     graders: EvalGraderConfig[];
     solution?: string;      // path to reference solution script
+    trialSetup?: string;    // task-specific setup command (runs per trial)
 
     // Per-task overrides
     agent?: string;
@@ -79,6 +80,7 @@ export interface ResolvedTask {
     workspace: WorkspaceMapping[];
     graders: ResolvedGrader[];
     solution?: string;      // resolved file path
+    trialSetup?: string;    // task-specific setup command (runs per trial)
     agent: string;
     provider: string;
     trials: number;

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -34,6 +34,11 @@ export interface EnvironmentConfig {
     memory_mb: number;
 }
 
+export interface TrialConfig {
+    setup?: string;
+    cleanup?: string;
+}
+
 /** Single eval task */
 export interface EvalTaskConfig {
     name: string;
@@ -41,7 +46,7 @@ export interface EvalTaskConfig {
     workspace?: WorkspaceMapping[];
     graders: EvalGraderConfig[];
     solution?: string;      // path to reference solution script
-    trialSetup?: string;    // task-specific setup command (runs per trial)
+    trialConfig?: TrialConfig;
 
     // Per-task overrides
     agent?: string;
@@ -80,7 +85,7 @@ export interface ResolvedTask {
     workspace: WorkspaceMapping[];
     graders: ResolvedGrader[];
     solution?: string;      // resolved file path
-    trialSetup?: string;    // task-specific setup command (runs per trial)
+    trialConfig?: TrialConfig;
     agent: string;
     provider: string;
     trials: number;

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -1,3 +1,5 @@
+import { ExpectedTool } from '../types';
+
 /**
  * eval.yaml configuration types.
  *
@@ -14,12 +16,13 @@ export interface WorkspaceMapping {
 
 /** Grader definition */
 export interface EvalGraderConfig {
-    type: 'deterministic' | 'llm_rubric';
+    type: 'deterministic' | 'llm_rubric' | 'tool_usage';
     setup?: string;     // commands to install grader dependencies (runs during image build)
     run?: string;       // inline script or file path (deterministic)
     rubric?: string;    // inline rubric or file path (llm_rubric)
     model?: string;     // LLM model override (e.g. 'gemini-2.0-flash', 'claude-sonnet-4-20250514')
     weight: number;
+    expectedTools?: ExpectedTool[]; // for tool_usage: list of expected tool calls
 }
 
 /** Docker configuration */
@@ -96,10 +99,11 @@ export interface ResolvedTask {
 }
 
 export interface ResolvedGrader {
-    type: 'deterministic' | 'llm_rubric';
+    type: 'deterministic' | 'llm_rubric' | 'tool_usage';
     setup?: string;     // resolved setup commands
     run?: string;       // resolved content for deterministic
     rubric?: string;    // resolved content for llm_rubric
     model?: string;     // LLM model override
     weight: number;
+    expectedTools?: ExpectedTool[]; // for tool_usage: list of expected tool calls
 }

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -35,7 +35,7 @@ export interface DockerConfig {
 export interface EnvironmentConfig {
     cpus: number;
     memory_mb: number;
-    binds?: string[];
+    mounts?: string[];
 }
 
 export interface TrialConfig {

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -35,11 +35,13 @@ export interface DockerConfig {
 export interface EnvironmentConfig {
     cpus: number;
     memory_mb: number;
+    binds?: string[];
 }
 
 export interface TrialConfig {
     setup?: string;
     cleanup?: string;
+    env?: Record<string, string>;
 }
 
 /** Single eval task */
@@ -50,6 +52,7 @@ export interface EvalTaskConfig {
     graders: EvalGraderConfig[];
     solution?: string;      // path to reference solution script
     trialConfig?: TrialConfig;
+    env?: Record<string, string>;
 
     // Per-task overrides
     agent?: string;
@@ -71,6 +74,7 @@ export interface EvalDefaults {
     grader_model?: string;  // default LLM grader model
     docker: DockerConfig;
     environment: EnvironmentConfig;
+    env?: Record<string, string>;
 }
 
 /** Top-level eval.yaml */
@@ -96,6 +100,7 @@ export interface ResolvedTask {
     grader_model?: string;  // inherited default model for LLM graders
     docker: DockerConfig;
     environment: EnvironmentConfig;
+    env?: Record<string, string>;
 }
 
 export interface ResolvedGrader {

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -75,6 +75,7 @@ export interface EvalDefaults {
     docker: DockerConfig;
     environment: EnvironmentConfig;
     env?: Record<string, string>;
+    trialConfig?: TrialConfig;
 }
 
 /** Top-level eval.yaml */

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -60,6 +60,7 @@ export interface EvalRunOptions {
         memory_mb: number;
         mounts?: string[];
     };
+    agentWorkingDir?: string;
 }
 
 export class EvalRunner {
@@ -228,7 +229,7 @@ export class EvalRunner {
 
             const agentTimeoutMs = opts.timeoutSec * 1000;
             const agentLogs = await withTimeout(
-                agent.run(instruction, workspace, loggedRunCommand),
+                agent.run(instruction, workspace, loggedRunCommand, { agentWorkingDir: opts.agentWorkingDir }),
                 agentTimeoutMs,
                 `Agent (limit: ${opts.timeoutSec}s)`
             );

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -52,6 +52,7 @@ export interface EvalRunOptions {
     instruction: string;
     graders: ResolvedGrader[];
     timeoutSec: number;
+    trialSetup?: string;
     graderModel?: string;       // default LLM grader model
     graderTimeoutSec?: number;  // timeout per grader (default: 120s)
     environment: {
@@ -173,9 +174,10 @@ export class EvalRunner {
         const startTime = Date.now();
 
         const spinner = new Spinner(`${index + 1}/${total}`, 'setting up environment');
-        const workspace = await this.provider.setup(taskPath, skillsPaths, opts, env);
+        let workspace: string | undefined;
 
         try {
+            workspace = await this.provider.setup(taskPath, skillsPaths, opts, env);
             const instruction = opts.instruction;
 
             sessionLog.push({
@@ -186,7 +188,7 @@ export class EvalRunner {
 
             spinner.update('running agent');
             const loggedRunCommand = async (cmd: string) => {
-                const result = await this.provider.runCommand(workspace, cmd, env);
+                const result = await this.provider.runCommand(workspace!, cmd, env);
                 commandCount++;
                 sessionLog.push({
                     type: 'command',
@@ -286,11 +288,12 @@ export class EvalRunner {
         } catch (err: any) {
             const duration_ms = Date.now() - startTime;
             const errorMsg = err?.message || String(err);
-            spinner.stop(`${fmt.fail('FAIL')}  ${errorMsg.substring(0, 50)}  ${fmt.dim((duration_ms / 1000).toFixed(1) + 's')}`);
+            spinner.stop(`${fmt.fail('FAIL')}  ${fmt.dim((duration_ms / 1000).toFixed(1) + 's')}`);
+            console.error(`\n${errorMsg}\n`);
 
 
             let diagnostics = '';
-            if (this.provider.diagnose) {
+            if (this.provider.diagnose && workspace) {
                 try {
                     diagnostics = await this.provider.diagnose(workspace);
                     console.log(diagnostics);
@@ -317,7 +320,9 @@ export class EvalRunner {
                 session_log: sessionLog
             };
         } finally {
-            await this.provider.cleanup(workspace);
+            if (workspace) {
+                await this.provider.cleanup(workspace);
+            }
         }
     }
 

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -63,10 +63,12 @@ export interface EvalRunOptions {
 export class EvalRunner {
     private provider: EnvironmentProvider;
     private logDir?: string;
+    private noRedact: boolean;
 
-    constructor(provider: EnvironmentProvider, logDir?: string) {
+    constructor(provider: EnvironmentProvider, logDir?: string, noRedact: boolean = false) {
         this.provider = provider;
         this.logDir = logDir;
+        this.noRedact = noRedact;
     }
 
     private timestamp(): string {
@@ -127,7 +129,7 @@ export class EvalRunner {
         };
 
         if (this.logDir) {
-            const sanitized = this.sanitize(report, env);
+            const sanitized = this.noRedact ? report : this.sanitize(report, env);
             await this.saveReport(sanitized);
         }
 

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -4,7 +4,7 @@ import {
     BaseAgent, EnvironmentProvider,
     LogEntry, TrialResult, EvalReport, GraderResult
 } from './types';
-import { ResolvedGrader } from './core/config.types';
+import { ResolvedGrader, TrialConfig } from './core/config.types';
 import { getGrader } from './graders';
 import { fmt, Spinner } from './utils/cli';
 
@@ -52,7 +52,7 @@ export interface EvalRunOptions {
     instruction: string;
     graders: ResolvedGrader[];
     timeoutSec: number;
-    trialSetup?: string;
+    trialConfig?: TrialConfig;
     graderModel?: string;       // default LLM grader model
     graderTimeoutSec?: number;  // timeout per grader (default: 120s)
     environment: {
@@ -177,7 +177,10 @@ export class EvalRunner {
         let workspace: string | undefined;
 
         try {
-            workspace = await this.provider.setup(taskPath, skillsPaths, opts, env);
+            workspace = await this.provider.setup(taskPath, skillsPaths, {
+                timeoutSec: opts.timeoutSec,
+                environment: opts.environment
+            }, env);
             const instruction = opts.instruction;
 
             sessionLog.push({
@@ -185,6 +188,22 @@ export class EvalRunner {
                 timestamp: this.timestamp(),
                 instruction
             });
+
+            if (opts.trialConfig?.setup) {
+                spinner.update('running trial setup');
+                const res = await this.provider.runCommand(workspace, opts.trialConfig.setup, env);
+                sessionLog.push({
+                    type: 'trial_setup',
+                    timestamp: this.timestamp(),
+                    command: opts.trialConfig.setup,
+                    stdout: res.stdout,
+                    stderr: res.stderr,
+                    exitCode: res.exitCode
+                });
+                if (res.exitCode !== 0) {
+                    throw new Error(`Per-trial setup failed with exit code ${res.exitCode}`);
+                }
+            }
 
             spinner.update('running agent');
             const loggedRunCommand = async (cmd: string) => {
@@ -321,6 +340,24 @@ export class EvalRunner {
             };
         } finally {
             if (workspace) {
+                if (opts.trialConfig?.cleanup) {
+                    try {
+                        const result = await this.provider.runCommand(workspace, opts.trialConfig.cleanup, env);
+                        sessionLog.push({
+                            type: 'trial_cleanup',
+                            timestamp: this.timestamp(),
+                            command: opts.trialConfig.cleanup,
+                            stdout: result.stdout,
+                            stderr: result.stderr,
+                            exitCode: result.exitCode
+                        });
+                        if (result.exitCode !== 0) {
+                            console.error(`Per-trial cleanup failed with exit code ${result.exitCode}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+                        }
+                    } catch (e) {
+                        console.error(`Error running per-trial cleanup: ${e}`);
+                    }
+                }
                 await this.provider.cleanup(workspace);
             }
         }

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -240,6 +240,7 @@ export class EvalRunner {
                 const graderDef = opts.graders[gIdx];
                 const grader = getGrader(graderDef.type);
                 spinner.update(`grading (${graderDef.type}${opts.graders.length > 1 ? ` ${gIdx + 1}/${opts.graders.length}` : ''})`);
+                spinner.render();
 
                 // Build grader config with file references for execution
                 const detIndex = opts.graders.slice(0, gIdx).filter(g => g.type === 'deterministic').length;
@@ -255,6 +256,7 @@ export class EvalRunner {
                         : undefined,
                     model: graderDef.model || opts.graderModel,
                     weight: graderDef.weight,
+                    expectedTools: graderDef.expectedTools,
                 };
 
                 const graderTimeoutMs = (opts.graderTimeoutSec ?? 120) * 1000;
@@ -341,8 +343,10 @@ export class EvalRunner {
         } finally {
             if (workspace) {
                 if (opts.trialConfig?.cleanup) {
+                    const cleanupSpinner = new Spinner(`${index + 1}/${total}`, 'cleaning up trial');
                     try {
                         const result = await this.provider.runCommand(workspace, opts.trialConfig.cleanup, env);
+                        cleanupSpinner.stop(fmt.pass('cleaned up'));
                         sessionLog.push({
                             type: 'trial_cleanup',
                             timestamp: this.timestamp(),

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -58,6 +58,7 @@ export interface EvalRunOptions {
     environment: {
         cpus: number;
         memory_mb: number;
+        mounts?: string[];
     };
 }
 
@@ -364,6 +365,7 @@ export class EvalRunner {
                             console.error(`Per-trial cleanup failed with exit code ${result.exitCode}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
                         }
                     } catch (e) {
+                        cleanupSpinner.stop(fmt.fail('failed'));
                         console.error(`Error running per-trial cleanup: ${e}`);
                     }
                 }

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -172,6 +172,11 @@ export class EvalRunner {
         const sessionLog: LogEntry[] = [];
         let commandCount = 0;
         const startTime = Date.now();
+        
+        const trialEnv = {
+            ...env,
+            ...opts.trialConfig?.env,
+        };
 
         const spinner = new Spinner(`${index + 1}/${total}`, 'setting up environment');
         let workspace: string | undefined;
@@ -180,7 +185,7 @@ export class EvalRunner {
             workspace = await this.provider.setup(taskPath, skillsPaths, {
                 timeoutSec: opts.timeoutSec,
                 environment: opts.environment
-            }, env);
+            }, trialEnv);
             const instruction = opts.instruction;
 
             sessionLog.push({
@@ -191,7 +196,7 @@ export class EvalRunner {
 
             if (opts.trialConfig?.setup) {
                 spinner.update('running trial setup');
-                const res = await this.provider.runCommand(workspace, opts.trialConfig.setup, env);
+                const res = await this.provider.runCommand(workspace, opts.trialConfig.setup, trialEnv);
                 sessionLog.push({
                     type: 'trial_setup',
                     timestamp: this.timestamp(),
@@ -207,7 +212,7 @@ export class EvalRunner {
 
             spinner.update('running agent');
             const loggedRunCommand = async (cmd: string) => {
-                const result = await this.provider.runCommand(workspace!, cmd, env);
+                const result = await this.provider.runCommand(workspace!, cmd, trialEnv);
                 commandCount++;
                 sessionLog.push({
                     type: 'command',
@@ -261,7 +266,7 @@ export class EvalRunner {
 
                 const graderTimeoutMs = (opts.graderTimeoutSec ?? 120) * 1000;
                 const result = await withTimeout(
-                    grader.grade(workspace, this.provider, graderConfig, taskPath, sessionLog, env),
+                    grader.grade(workspace, this.provider, graderConfig, taskPath, sessionLog, trialEnv),
                     graderTimeoutMs,
                     `Grader ${graderDef.type} (limit: ${opts.graderTimeoutSec ?? 120}s)`
                 );
@@ -345,7 +350,7 @@ export class EvalRunner {
                 if (opts.trialConfig?.cleanup) {
                     const cleanupSpinner = new Spinner(`${index + 1}/${total}`, 'cleaning up trial');
                     try {
-                        const result = await this.provider.runCommand(workspace, opts.trialConfig.cleanup, env);
+                        const result = await this.provider.runCommand(workspace, opts.trialConfig.cleanup, trialEnv);
                         cleanupSpinner.stop(fmt.pass('cleaned up'));
                         sessionLog.push({
                             type: 'trial_cleanup',

--- a/src/graders/index.ts
+++ b/src/graders/index.ts
@@ -1,6 +1,7 @@
 import { GraderConfig, GraderResult, EnvironmentProvider } from '../types';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { ToolUsageGrader } from './tool_usage';
 
 export interface Grader {
     grade(
@@ -255,6 +256,7 @@ export function getGrader(type: string): Grader {
     switch (type) {
         case 'deterministic': return new DeterministicGrader();
         case 'llm_rubric': return new LLMGrader();
+        case 'tool_usage': return new ToolUsageGrader();
         default: throw new Error(`Unknown grader type: ${type}`);
     }
 }

--- a/src/graders/tool_usage.ts
+++ b/src/graders/tool_usage.ts
@@ -1,0 +1,124 @@
+import { Grader } from './index';
+import { GraderConfig, GraderResult, EnvironmentProvider } from '../types';
+
+export class ToolUsageGrader implements Grader {
+    async grade(
+        workspace: string,
+        provider: EnvironmentProvider,
+        config: GraderConfig,
+        _taskPath: string,
+        _sessionLog: any[],
+        env?: Record<string, string>
+    ): Promise<GraderResult> {
+        const expectedTools = config.expectedTools || [];
+
+        if (expectedTools.length === 0) {
+            return {
+                grader_type: 'tool_usage',
+                score: 1.0,
+                weight: config.weight,
+                details: 'No tools expected.'
+            };
+        }
+
+        // Read .tool_calls.log from workspace
+        const result = await provider.runCommand(workspace, 'cat .tool_calls.log', env);
+
+        if (result.exitCode !== 0) {
+            // If file doesn't exist, it might mean no tools were called!
+            // Let's check if the file exists first or handle the error.
+            // If cat fails because file doesn't exist, it usually means no tools were called.
+            // So calledTools is empty.
+            // Let's check if stderr contains "No such file or directory".
+            if (result.stderr.includes('No such file or directory')) {
+                const expectedStrs = expectedTools.map(t => `${t.name}${t.args ? `(${JSON.stringify(t.args)})` : ''}`);
+                return {
+                    grader_type: 'tool_usage',
+                    score: 0.0,
+                    weight: config.weight,
+                    details: `Missing expected tools: ${expectedStrs.join(', ')}. No tools were called.`
+                };
+            }
+
+            return {
+                grader_type: 'tool_usage',
+                score: 0.0,
+                weight: config.weight,
+                details: `Failed to read .tool_calls.log. Exit code: ${result.exitCode}. Stderr: ${result.stderr.trim()}`
+            };
+        }
+
+        const lines = result.stdout.split('\n');
+        const calledTools: { name: string, args: Record<string, any> }[] = [];
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+                const event = JSON.parse(trimmed);
+                if (event.type === 'tool_use') {
+                    const toolName = event.tool_name || event.name || (event.tool_use && event.tool_use.name);
+                    const parameters = event.parameters || event.args || (event.tool_use && event.tool_use.args) || {};
+                    if (toolName) {
+                        calledTools.push({ name: toolName, args: parameters });
+                    }
+                }
+            } catch (e) {
+                // Ignore parse errors
+            }
+        }
+
+        const missingTools: string[] = [];
+
+        for (const et of expectedTools) {
+            const expectedName = et.name;
+            const expectedArgs = et.args;
+
+            const found = calledTools.find(ct => {
+                if (ct.name !== expectedName) return false;
+                if (!expectedArgs) return true; // Name match is enough if no args expected
+
+                // Check if expectedArgs is a subset of ct.args
+                return isSubset(expectedArgs, ct.args);
+            });
+
+            if (!found) {
+                missingTools.push(`${et.name}${et.args ? `(${JSON.stringify(et.args)})` : ''}`);
+            }
+        }
+
+        if (missingTools.length === 0) {
+            const expectedStrs = expectedTools.map(t => `${t.name}${t.args ? `(${JSON.stringify(t.args)})` : ''}`);
+            return {
+                grader_type: 'tool_usage',
+                score: 1.0,
+                weight: config.weight,
+                details: `All expected tools were called: ${expectedStrs.join(', ')}`
+            };
+        } else {
+            const calledStrs = calledTools.map(t => `${t.name}(${JSON.stringify(t.args)})`);
+            return {
+                grader_type: 'tool_usage',
+                score: 0.0,
+                weight: config.weight,
+                details: `Missing expected tools: ${missingTools.join(', ')}. Called tools: ${calledStrs.join(', ')}`
+            };
+        }
+    }
+}
+
+function isSubset(subset: Record<string, any>, superset: Record<string, any>): boolean {
+    for (const key in subset) {
+        if (subset.hasOwnProperty(key)) {
+            const val = subset[key];
+            const superVal = superset[key];
+            if (typeof val === 'object' && val !== null) {
+                if (typeof superVal !== 'object' || superVal === null) return false;
+                if (!isSubset(val, superVal)) return false;
+            } else if (val !== superVal) {
+                return false;
+            }
+        }
+    }
+    return true;
+}

--- a/src/providers/docker.ts
+++ b/src/providers/docker.ts
@@ -48,33 +48,54 @@ export class DockerProvider implements EnvironmentProvider {
                 Tty: false
             });
 
-            await tmpContainer.start();
+            try {
+                await tmpContainer.start();
 
-            const discoveryDirs = ['/workspace/.agents/skills', '/workspace/.claude/skills'];
-            for (const dir of discoveryDirs) {
-                const mkdirExec = await tmpContainer.exec({ Cmd: ['mkdir', '-p', dir], AttachStdout: true, AttachStderr: true });
-                const mkdirStream = await mkdirExec.start({});
+                // Detect $HOME in container
+                const homeExec = await tmpContainer.exec({ Cmd: ['sh', '-c', 'echo $HOME'], AttachStdout: true });
+                const homeStream = await homeExec.start({});
+                let homeDir = '';
+                
+                const stdoutStream = new (require('stream').PassThrough)();
+                stdoutStream.on('data', (chunk: Buffer) => { homeDir += chunk.toString(); });
+                
+                this.docker.modem.demuxStream(homeStream, stdoutStream, new (require('stream').PassThrough)());
+
                 await new Promise<void>((resolve) => {
-                    mkdirStream.on('end', resolve);
-                    mkdirStream.on('error', resolve);
-                    mkdirStream.resume();
+                    homeStream.on('end', resolve);
+                    homeStream.on('error', resolve);
                 });
+                homeDir = homeDir.trim() || '/root';
 
-                for (const skillPath of skillsPaths) {
-                    const skillName = path.basename(skillPath);
-                    const archive = await this.createTarFromDir(skillPath, skillName);
-                    await tmpContainer.putArchive(archive, { path: dir });
+                const discoveryDirs = [
+                    path.join(homeDir, '.agents', 'skills'),
+                    path.join(homeDir, '.claude', 'skills')
+                ];
+                for (const dir of discoveryDirs) {
+                    const mkdirExec = await tmpContainer.exec({ Cmd: ['mkdir', '-p', dir], AttachStdout: true, AttachStderr: true });
+                    const mkdirStream = await mkdirExec.start({});
+                    await new Promise<void>((resolve) => {
+                        mkdirStream.on('end', resolve);
+                        mkdirStream.on('error', resolve);
+                        mkdirStream.resume();
+                    });
+
+                    for (const skillPath of skillsPaths) {
+                        const skillName = path.basename(skillPath);
+                        const archive = await this.createTarFromDir(skillPath, skillName);
+                        await tmpContainer.putArchive(archive, { path: dir });
+                    }
                 }
+
+                // Commit the container with skills baked in
+                await tmpContainer.commit({ repo: `${baseName}-ready` });
+                this.preparedImage = `${baseName}-ready`;
+            } finally {
+                // Clean up temp container and base image
+                await tmpContainer.kill().catch(() => { });
+                await tmpContainer.remove({ force: true }).catch(() => { });
+                await this.docker.getImage(baseName).remove({ force: true }).catch(() => { });
             }
-
-            // Commit the container with skills baked in
-            const committed = await tmpContainer.commit({ repo: `${baseName}-ready` });
-            this.preparedImage = `${baseName}-ready`;
-
-            // Clean up temp container and base image
-            await tmpContainer.kill().catch(() => { });
-            await tmpContainer.remove({ force: true }).catch(() => { });
-            await this.docker.getImage(baseName).remove({ force: true }).catch(() => { });
         } else {
             this.preparedImage = baseName;
         }

--- a/src/providers/docker.ts
+++ b/src/providers/docker.ts
@@ -107,8 +107,21 @@ export class DockerProvider implements EnvironmentProvider {
             }
         });
 
-        await container.start();
-        return container.id;
+        try {
+            await container.start();
+
+            if (opts.trialSetup) {
+                const result = await this.runCommand(container.id, opts.trialSetup, env);
+                if (result.exitCode !== 0) {
+                    throw new Error(`Per-trial setup failed with exit code ${result.exitCode}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+                }
+            }
+
+            return container.id;
+        } catch (e) {
+            await this.cleanup(container.id);
+            throw e;
+        }
     }
 
     /**

--- a/src/providers/docker.ts
+++ b/src/providers/docker.ts
@@ -104,6 +104,7 @@ export class DockerProvider implements EnvironmentProvider {
             HostConfig: {
                 NanoCpus: config.environment.cpus * 1e9,
                 Memory: config.environment.memory_mb * 1024 * 1024,
+                Binds: config.environment.mounts,
             }
         });
 
@@ -191,13 +192,21 @@ export class DockerProvider implements EnvironmentProvider {
         const container = this.docker.getContainer(containerId);
         const envPairs = env ? Object.entries(env).map(([k, v]) => `${k}=${v}`) : [];
 
-        const exec = await container.exec({
-            Cmd: ['/bin/bash', '-c', command],
-            AttachStdout: true,
-            AttachStderr: true,
-            Tty: false,
-            Env: envPairs
-        });
+        let exec;
+        try {
+            exec = await container.exec({
+                Cmd: ['/bin/bash', '-c', command],
+                AttachStdout: true,
+                AttachStderr: true,
+                Tty: false,
+                Env: envPairs
+            });
+        } catch (e: any) {
+            if (e.statusCode === 409 || e.message.includes('container stopped/paused')) {
+                throw new Error(`Container is not running`);
+            }
+            throw e;
+        }
 
         const stream = await exec.start({});
 
@@ -227,6 +236,16 @@ export class DockerProvider implements EnvironmentProvider {
 
     async diagnose(containerId: string): Promise<string> {
         const container = this.docker.getContainer(containerId);
+        
+        try {
+            const inspect = await container.inspect();
+            if (!inspect.State.Running) {
+                return `=== Docker Container Diagnostics ===\nContainer is not running (State: ${JSON.stringify(inspect.State)})`;
+            }
+        } catch (e) {
+            return `=== Docker Container Diagnostics ===\nFailed to inspect container: ${e}`;
+        }
+
         const lines: string[] = ['=== Docker Container Diagnostics ==='];
 
         const runDiag = async (label: string, cmd: string) => {

--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -4,27 +4,39 @@ import { spawn } from 'child_process';
 import { EnvironmentProvider, EnvironmentSetupOpts, CommandResult } from '../types';
 
 export class LocalProvider implements EnvironmentProvider {
-    async setup(taskPath: string, skillsPaths: string[], _opts: EnvironmentSetupOpts, env?: Record<string, string>): Promise<string> {
+    async setup(taskPath: string, skillsPaths: string[], opts: EnvironmentSetupOpts, env?: Record<string, string>): Promise<string> {
         const tempDir = path.join('/tmp', `skillgrade-${Math.random().toString(36).substring(7)}`);
         await fs.ensureDir(tempDir);
-        await fs.copy(taskPath, tempDir);
+        try {
+            await fs.copy(taskPath, tempDir);
 
-        // Inject skills into agent discovery paths
-        // Gemini: .agents/skills/  |  Claude: .claude/skills/
-        const discoveryDirs = [
-            path.join(tempDir, '.agents', 'skills'),
-            path.join(tempDir, '.claude', 'skills'),
-        ];
+            // Inject skills into agent discovery paths
+            // Gemini: .agents/skills/  |  Claude: .claude/skills/
+            const discoveryDirs = [
+                path.join(tempDir, '.agents', 'skills'),
+                path.join(tempDir, '.claude', 'skills'),
+            ];
 
-        for (const skillsDir of discoveryDirs) {
-            await fs.ensureDir(skillsDir);
-            for (const spath of skillsPaths) {
-                const skillName = path.basename(spath);
-                await fs.copy(spath, path.join(skillsDir, skillName));
+            for (const skillsDir of discoveryDirs) {
+                await fs.ensureDir(skillsDir);
+                for (const spath of skillsPaths) {
+                    const skillName = path.basename(spath);
+                    await fs.copy(spath, path.join(skillsDir, skillName));
+                }
             }
-        }
 
-        return tempDir;
+            if (opts.trialSetup) {
+                const result = await this.runCommand(tempDir, opts.trialSetup, env);
+                if (result.exitCode !== 0) {
+                    throw new Error(`Per-trial setup failed with exit code ${result.exitCode}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+                }
+            }
+
+            return tempDir;
+        } catch (e) {
+            await this.cleanup(tempDir);
+            throw e;
+        }
     }
 
     async cleanup(workspacePath: string): Promise<void> {

--- a/src/providers/local.ts
+++ b/src/providers/local.ts
@@ -12,16 +12,21 @@ export class LocalProvider implements EnvironmentProvider {
 
             // Inject skills into agent discovery paths
             // Gemini: .agents/skills/  |  Claude: .claude/skills/
-            const discoveryDirs = [
-                path.join(tempDir, '.agents', 'skills'),
-                path.join(tempDir, '.claude', 'skills'),
-            ];
+            if (skillsPaths.length > 0) {
+                const homeDir = process.env.HOME || '/root';
+                const discoveryDirs = [
+                    path.join(homeDir, '.agents', 'skills'),
+                    path.join(homeDir, '.claude', 'skills'),
+                ];
 
-            for (const skillsDir of discoveryDirs) {
-                await fs.ensureDir(skillsDir);
-                for (const spath of skillsPaths) {
-                    const skillName = path.basename(spath);
-                    await fs.copy(spath, path.join(skillsDir, skillName));
+                console.warn(`[SkillGrade] Injecting skills into ${homeDir}/.agents/skills and .claude/skills`);
+
+                for (const skillsDir of discoveryDirs) {
+                    await fs.ensureDir(skillsDir);
+                    for (const spath of skillsPaths) {
+                        const skillName = path.basename(spath);
+                        await fs.copy(spath, path.join(skillsDir, skillName));
+                    }
                 }
             }
 

--- a/src/skillgrade.ts
+++ b/src/skillgrade.ts
@@ -102,6 +102,7 @@ async function main() {
         provider: getFlag('provider'),
         grader: getFlag('grader'),
         output: outputDir,
+        noRedact: hasFlag('no-redact'),
     });
 
     if (openPreview) {
@@ -137,6 +138,7 @@ function printHelp() {
     --ci               CI mode: exit non-zero if below threshold
     --threshold=0.8    Pass rate threshold for CI mode
     --preview          Open CLI results after running
+    --no-redact        Disable redaction of environment variables in reports
 
   Examples:
     skillgrade init                # scaffold eval.yaml

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export abstract class BaseAgent {
 /** Options passed to environment providers for setup */
 export interface EnvironmentSetupOpts {
     timeoutSec: number;
+    trialSetup?: string;
     environment: {
         cpus: number;
         memory_mb: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface GraderResult {
 }
 
 export interface LogEntry {
-    type: 'agent_start' | 'command' | 'agent_result' | 'grader' | 'reward';
+    type: 'agent_start' | 'command' | 'agent_result' | 'grader' | 'reward' | 'trial_setup' | 'trial_cleanup';
     timestamp: string;
     instruction?: string;
     command?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,8 @@ export abstract class BaseAgent {
     abstract run(
         instruction: string,
         workspacePath: string,
-        runCommand: (cmd: string) => Promise<CommandResult>
+        runCommand: (cmd: string) => Promise<CommandResult>,
+        options?: { agentWorkingDir?: string }
     ): Promise<string>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface EnvironmentSetupOpts {
     environment: {
         cpus: number;
         memory_mb: number;
+        mounts?: string[];
     };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,17 @@ export interface CommandResult {
     exitCode: number;
 }
 
+export interface ExpectedTool {
+    name: string;
+    args?: Record<string, any>;
+}
+
 export interface GraderConfig {
-    type: 'deterministic' | 'llm_rubric';
+    type: 'deterministic' | 'llm_rubric' | 'tool_usage';
     command?: string;         // for deterministic: shell command to execute (e.g. 'bash tests/test.sh')
     rubric?: string;          // for llm_rubric: file path to rubric (e.g. 'prompts/quality.md')
     model?: string;           // for llm_rubric: LLM model override
+    expectedTools?: ExpectedTool[];  // for tool_usage: list of expected tool calls
     weight: number;
 }
 

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -119,7 +119,7 @@ export class Spinner {
         }
     }
 
-    private render() {
+    render() {
         const frame = this.frames[this.frameIdx % this.frames.length];
         this.frameIdx++;
         const elapsed = ((Date.now() - this.startTime) / 1000).toFixed(0);

--- a/src/viewer.html
+++ b/src/viewer.html
@@ -438,7 +438,9 @@
       border-left-color: var(--purple);
     }
 
-    .log-entry.command {
+    .log-entry.command,
+    .log-entry.trial_setup,
+    .log-entry.trial_cleanup {
       border-left-color: var(--blue);
     }
 
@@ -471,7 +473,9 @@
       color: var(--purple);
     }
 
-    .command .log-label {
+    .command .log-label,
+    .trial_setup .log-label,
+    .trial_cleanup .log-label {
       background: var(--blue-bg);
       color: var(--blue);
     }
@@ -744,6 +748,8 @@
           body = '<pre class="code-block">' + esc(e.instruction || '') + '</pre>';
           break;
         case 'command':
+        case 'trial_setup':
+        case 'trial_cleanup':
           body = '<div class="cmd-line">' + esc(e.command || '') + '</div>'
             + '<pre class="code-block">' + esc(e.stdout || '')
             + (e.stderr ? '<span class="stderr-text">' + esc(e.stderr) + '</span>' : '')

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -63,6 +63,20 @@ describe('GeminiAgent', () => {
     const expectedB64 = Buffer.from(instruction).toString('base64');
     expect(capturedCmd).toContain(expectedB64);
   });
+
+  it('prepends cd to gemini command when agentWorkingDir is provided', async () => {
+    const agent = new GeminiAgent();
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand, { agentWorkingDir: 'sub-dir' });
+
+    expect(commands).toHaveLength(2);
+    expect(commands[1]).toContain('cd sub-dir && gemini');
+  });
 });
 
 describe('ClaudeAgent', () => {

--- a/tests/commands.run.test.ts
+++ b/tests/commands.run.test.ts
@@ -15,6 +15,7 @@ vi.mock('fs-extra', () => ({
 import * as fs from 'fs-extra';
 import { ResolvedTask } from '../src/core/config.types';
 import { TaskConfig } from '../src/types';
+import { prepareTempTaskDir } from '../src/commands/run';
 
 const mockPathExists = vi.mocked(fs.pathExists);
 const mockEnsureDir = vi.mocked(fs.ensureDir);
@@ -203,5 +204,78 @@ SINGLE='quoted'
       PLAIN: 'text',
       SINGLE: 'quoted',
     });
+  });
+});
+
+describe('prepareTempTaskDir', () => {
+  it('uses temp file for inline workspace content', async () => {
+    const resolved: ResolvedTask = {
+      name: 'test-task',
+      instruction: 'do it',
+      workspace: [
+        {
+          content: '{\n  "mcpServers": {}\n}',
+          dest: '/root/.gemini/settings.json',
+        },
+      ],
+      graders: [],
+      agent: 'gemini',
+      provider: 'docker',
+      trials: 5,
+      timeout: 300,
+      docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
+    };
+
+    mockPathExists.mockResolvedValue(false as any);
+
+    await prepareTempTaskDir(resolved, '/base', '/tmp');
+
+    expect(mockWriteFile).toHaveBeenCalled();
+    const dockerfileCall = mockWriteFile.mock.calls.find(call => 
+      (call[0] as string).endsWith('Dockerfile')
+    );
+    expect(dockerfileCall).toBeTruthy();
+    const content = dockerfileCall![1] as string;
+    expect(content).toContain("COPY workspace_files/inline_file_1.tmp /root/.gemini/settings.json");
+
+    const inlineFileCall = mockWriteFile.mock.calls.find(call => 
+      (call[0] as string).endsWith(path.join('workspace_files', 'inline_file_1.tmp'))
+    );
+    expect(inlineFileCall).toBeTruthy();
+    expect(inlineFileCall![1]).toBe('{\n  "mcpServers": {}\n}');
+  });
+
+  it('uses regular COPY for file paths', async () => {
+    const resolved: ResolvedTask = {
+      name: 'test-task',
+      instruction: 'do it',
+      workspace: [
+        {
+          src: 'fixtures/app.js',
+          dest: 'app.js',
+        },
+      ],
+      graders: [],
+      agent: 'gemini',
+      provider: 'docker',
+      trials: 5,
+      timeout: 300,
+      docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
+    };
+
+    mockPathExists.mockResolvedValue(true as any);
+
+    await prepareTempTaskDir(resolved, '/base', '/tmp');
+
+    expect(mockWriteFile).toHaveBeenCalled();
+    const dockerfileCall = mockWriteFile.mock.calls.find(call => 
+      (call[0] as string).endsWith('Dockerfile')
+    );
+    expect(dockerfileCall).toBeTruthy();
+    const content = dockerfileCall![1] as string;
+    expect(content).toContain('COPY app.js app.js');
+    expect(content).not.toContain("COPY <<'EOF'");
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -91,7 +91,7 @@ tasks:
         run: "echo ok"
 `;
     mockReadFile.mockResolvedValue(yaml as any);
-    await expect(loadEvalConfig('/test')).rejects.toThrow('without src/dest');
+    await expect(loadEvalConfig('/test')).rejects.toThrow('without dest');
   });
 
   it('parses valid config correctly', async () => {
@@ -326,6 +326,23 @@ tasks:
 
     const config = await loadEvalConfig('/test');
     expect(config.defaults.environment.mounts).toEqual(['/host:/container:ro']);
+  });
+
+  it('parses agentWorkingDir correctly', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+tasks:
+  - name: test-task
+    instruction: "do it"
+    agentWorkingDir: "sub-dir"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.tasks[0].agentWorkingDir).toBe('sub-dir');
   });
 });
 
@@ -577,5 +594,19 @@ describe('resolveTask', () => {
     expect(resolved.environment.mounts).toHaveLength(1);
     expect(resolved.environment.mounts![0]).not.toContain('~');
     expect(resolved.environment.mounts![0]).toContain(require('os').homedir());
+  });
+
+  it('resolves agentWorkingDir correctly', async () => {
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'do it',
+      agentWorkingDir: 'sub-dir',
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    mockPathExists.mockResolvedValue(false as any);
+
+    const resolved = await resolveTask(task, defaults, '/base');
+    expect(resolved.agentWorkingDir).toBe('sub-dir');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -129,13 +129,15 @@ tasks:
     expect(config.tasks[0].graders[1].type).toBe('llm_rubric');
   });
 
-  it('parses trialSetup correctly', async () => {
+  it('parses trialConfig correctly', async () => {
     mockPathExists.mockResolvedValue(true as any);
     const yaml = `version: "1"
 tasks:
   - name: test-task
     instruction: "do it"
-    trialSetup: "echo setup"
+    trialConfig:
+      setup: "echo setup"
+      cleanup: "echo cleanup"
     graders:
       - type: deterministic
         run: "echo ok"
@@ -143,7 +145,8 @@ tasks:
     mockReadFile.mockResolvedValue(yaml as any);
 
     const config = await loadEvalConfig('/test');
-    expect(config.tasks[0].trialSetup).toBe('echo setup');
+    expect(config.tasks[0].trialConfig?.setup).toBe('echo setup');
+    expect(config.tasks[0].trialConfig?.cleanup).toBe('echo cleanup');
   });
 
   it('applies default values when defaults not specified', async () => {
@@ -234,6 +237,7 @@ describe('resolveTask', () => {
     timeout: 300,
     threshold: 0.8,
     docker: { base: 'node:20-slim' },
+    environment: { cpus: 1, memory_mb: 512 },
   };
 
   it('applies defaults when task has no overrides', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -129,6 +129,23 @@ tasks:
     expect(config.tasks[0].graders[1].type).toBe('llm_rubric');
   });
 
+  it('parses trialSetup correctly', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+tasks:
+  - name: test-task
+    instruction: "do it"
+    trialSetup: "echo setup"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.tasks[0].trialSetup).toBe('echo setup');
+  });
+
   it('applies default values when defaults not specified', async () => {
     mockPathExists.mockResolvedValue(true as any);
     const yaml = `version: "1"

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -253,6 +253,59 @@ tasks:
     expect(config.tasks[0].env).toEqual({ TASK_VAR: 'task' });
     expect(config.tasks[0].trialConfig?.env).toEqual({ TRIAL_VAR: 'trial' });
   });
+
+  it('throws when defaults.environment.mounts is not an array', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  environment:
+    mounts: "not an array"
+tasks:
+  - name: test-task
+    instruction: "do it"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+    await expect(loadEvalConfig('/test')).rejects.toThrow('defaults.environment.mounts must be an array');
+  });
+
+  it('throws when task environment.mounts is not an array', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+tasks:
+  - name: test-task
+    instruction: "do it"
+    environment:
+      mounts: "not an array"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+    await expect(loadEvalConfig('/test')).rejects.toThrow('environment.mounts must be an array');
+  });
+
+  it('parses valid mounts correctly', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  environment:
+    mounts:
+      - "/host:/container:ro"
+tasks:
+  - name: test-task
+    instruction: "do it"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.defaults.environment.mounts).toEqual(['/host:/container:ro']);
+  });
 });
 
 describe('resolveTask', () => {
@@ -422,5 +475,23 @@ describe('resolveTask', () => {
       OVERRIDDEN: 'task',
     });
     expect(resolved.trialConfig?.env).toEqual({ TRIAL_VAR: 'trial' });
+  });
+
+  it('resolves ~ in mounts', async () => {
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'do it',
+      environment: {
+        mounts: ['~/.config:/tmp/config'],
+      },
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    mockPathExists.mockResolvedValue(false as any);
+
+    const resolved = await resolveTask(task, defaults, '/base');
+    expect(resolved.environment.mounts).toHaveLength(1);
+    expect(resolved.environment.mounts![0]).not.toContain('~');
+    expect(resolved.environment.mounts![0]).toContain(require('os').homedir());
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -149,6 +149,27 @@ tasks:
     expect(config.tasks[0].trialConfig?.cleanup).toBe('echo cleanup');
   });
 
+  it('parses default trialConfig correctly', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  trialConfig:
+    setup: "echo default setup"
+    cleanup: "echo default cleanup"
+tasks:
+  - name: test-task
+    instruction: "do it"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.defaults.trialConfig?.setup).toBe('echo default setup');
+    expect(config.defaults.trialConfig?.cleanup).toBe('echo default cleanup');
+  });
+
   it('applies default values when defaults not specified', async () => {
     mockPathExists.mockResolvedValue(true as any);
     const yaml = `version: "1"
@@ -475,6 +496,69 @@ describe('resolveTask', () => {
       OVERRIDDEN: 'task',
     });
     expect(resolved.trialConfig?.env).toEqual({ TRIAL_VAR: 'trial' });
+  });
+
+  it('merges trialConfig correctly', async () => {
+    const defaultsWithTrialConfig = {
+      ...defaults,
+      trialConfig: {
+        setup: 'echo default setup',
+        cleanup: 'echo default cleanup',
+        env: { DEFAULT_VAR: 'default' },
+      },
+    };
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'do it',
+      trialConfig: {
+        setup: 'echo task setup',
+        cleanup: 'echo task cleanup',
+        env: { TASK_VAR: 'task' },
+      },
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    mockPathExists.mockResolvedValue(false as any);
+
+    const resolved = await resolveTask(task, defaultsWithTrialConfig, '/base');
+    expect(resolved.trialConfig?.setup).toBe('echo default setup\necho task setup');
+    expect(resolved.trialConfig?.cleanup).toBe('echo default cleanup\necho task cleanup');
+    expect(resolved.trialConfig?.env).toEqual({
+      DEFAULT_VAR: 'default',
+      TASK_VAR: 'task',
+    });
+  });
+
+  it('merges trialConfig with file references correctly', async () => {
+    const defaultsWithTrialConfig = {
+      ...defaults,
+      trialConfig: {
+        setup: 'default_setup.sh',
+        cleanup: 'echo default cleanup',
+      },
+    };
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'do it',
+      trialConfig: {
+        setup: 'echo task setup',
+        cleanup: 'task_cleanup.sh',
+      },
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    mockPathExists.mockImplementation(async (p) => typeof p === 'string' && (p.endsWith('default_setup.sh') || p.endsWith('task_cleanup.sh')));
+    mockReadFile.mockImplementation(async (p) => {
+        if (typeof p === 'string') {
+            if (p.endsWith('default_setup.sh')) return 'echo from default file';
+            if (p.endsWith('task_cleanup.sh')) return 'echo from task file';
+        }
+        return '' as any;
+    });
+
+    const resolved = await resolveTask(task, defaultsWithTrialConfig, '/base');
+    expect(resolved.trialConfig?.setup).toBe('echo from default file\necho task setup');
+    expect(resolved.trialConfig?.cleanup).toBe('echo default cleanup\necho from task file');
   });
 
   it('resolves ~ in mounts', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -227,6 +227,32 @@ tasks:
     const config = await loadEvalConfig('/test');
     expect(config.tasks[0].graders[0].weight).toBe(1.0);
   });
+
+  it('parses env variables correctly', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  env:
+    GLOBAL_VAR: "global"
+tasks:
+  - name: test-task
+    instruction: "do it"
+    env:
+      TASK_VAR: "task"
+    trialConfig:
+      env:
+        TRIAL_VAR: "trial"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.defaults.env).toEqual({ GLOBAL_VAR: 'global' });
+    expect(config.tasks[0].env).toEqual({ TASK_VAR: 'task' });
+    expect(config.tasks[0].trialConfig?.env).toEqual({ TRIAL_VAR: 'trial' });
+  });
 });
 
 describe('resolveTask', () => {
@@ -370,5 +396,31 @@ describe('resolveTask', () => {
 
     const resolved = await resolveTask(task, defaults, '/base');
     expect(resolved.graders[0].setup).toBe('npm install -g typescript');
+  });
+
+  it('merges env variables correctly', async () => {
+    const defaultsWithEnv = {
+      ...defaults,
+      env: { GLOBAL_VAR: 'global', OVERRIDDEN: 'global' },
+    };
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'do it',
+      env: { TASK_VAR: 'task', OVERRIDDEN: 'task' },
+      trialConfig: {
+        env: { TRIAL_VAR: 'trial' },
+      },
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    mockPathExists.mockResolvedValue(false as any);
+
+    const resolved = await resolveTask(task, defaultsWithEnv, '/base');
+    expect(resolved.env).toEqual({
+      GLOBAL_VAR: 'global',
+      TASK_VAR: 'task',
+      OVERRIDDEN: 'task',
+    });
+    expect(resolved.trialConfig?.env).toEqual({ TRIAL_VAR: 'trial' });
   });
 });

--- a/tests/evalRunner.test.ts
+++ b/tests/evalRunner.test.ts
@@ -373,4 +373,5 @@ describe('EvalRunner', () => {
     expect(setupLog).toBeTruthy();
     expect(setupLog?.command).toBe('echo setup');
   });
+
 });

--- a/tests/evalRunner.test.ts
+++ b/tests/evalRunner.test.ts
@@ -98,6 +98,22 @@ describe('EvalRunner', () => {
     expect(report.trials[0].grader_results).toEqual([]);
   });
 
+  it('handles provider setup failure gracefully', async () => {
+    const provider = makeMockProvider();
+    provider.setup = vi.fn().mockRejectedValue(new Error('Setup failed'));
+
+    const agent = makeMockAgent();
+    const runner = new EvalRunner(provider);
+    
+    const report = await runner.runEval(agent, '/task', [], makeEvalOpts(), 1);
+
+    expect(report.trials).toHaveLength(1);
+    expect(report.trials[0].reward).toBe(0);
+    expect(report.trials[0].session_log.length).toBeGreaterThan(0);
+    const lastLog = report.trials[0].session_log[report.trials[0].session_log.length - 1];
+    expect(lastLog.output).toContain('Setup failed');
+  });
+
   it('saves report to logDir when provided', async () => {
     const provider = makeMockProvider();
     const agent = makeMockAgent();

--- a/tests/evalRunner.test.ts
+++ b/tests/evalRunner.test.ts
@@ -149,6 +149,36 @@ describe('EvalRunner', () => {
     expect(reportStr).toContain('[REDACTED]');
   });
 
+  it('does not sanitize secrets from report when noRedact is true', async () => {
+    const provider = makeMockProvider();
+    (provider.runCommand as any).mockResolvedValue({
+      stdout: 'The key is MY_SECRET_VALUE_123',
+      stderr: '',
+      exitCode: 0,
+    });
+    const agent = {
+      run: vi.fn().mockImplementation(async (instruction: string, workspace: string, runCommand: any) => {
+        const res = await runCommand('echo test');
+        return `Output: ${res.stdout}`;
+      }),
+    } as any as BaseAgent;
+
+    const gradersModule = await import('../src/graders/index');
+    vi.spyOn(gradersModule, 'getGrader').mockReturnValue({
+      grade: vi.fn().mockResolvedValue({
+        grader_type: 'deterministic', score: 1.0, weight: 1.0, details: 'ok',
+      }),
+    });
+
+    const runner = new EvalRunner(provider, '/logs', true);
+    await runner.runEval(agent, '/task', [], makeEvalOpts(), 1, { SECRET: 'MY_SECRET_VALUE_123' });
+
+    const writtenReport = (mockWriteJSON.mock.calls[0] as any[])[1];
+    const reportStr = JSON.stringify(writtenReport);
+    expect(reportStr).toContain('MY_SECRET_VALUE_123');
+    expect(reportStr).not.toContain('[REDACTED]');
+  });
+
   it('calculates correct pass_rate and pass_at_k', async () => {
     const provider = makeMockProvider();
     const agent = makeMockAgent();

--- a/tests/evalRunner.test.ts
+++ b/tests/evalRunner.test.ts
@@ -318,4 +318,59 @@ describe('EvalRunner', () => {
 
     expect(report.trials[0].grader_results).toHaveLength(3);
   });
+
+  it('executes and logs trialConfig.cleanup in finally block', async () => {
+    const provider = makeMockProvider();
+    const agent = makeMockAgent();
+    const opts = makeEvalOpts({
+      trialConfig: {
+        cleanup: 'echo cleanup'
+      }
+    } as any);
+
+    const gradersModule = await import('../src/graders/index');
+    vi.spyOn(gradersModule, 'getGrader').mockReturnValue({
+      grade: vi.fn().mockResolvedValue({
+        grader_type: 'deterministic', score: 1.0, weight: 1.0, details: 'ok',
+      }),
+    });
+
+    const runner = new EvalRunner(provider);
+    const report = await runner.runEval(agent, '/task', [], opts, 1);
+
+    expect(provider.runCommand).toHaveBeenCalledWith('/workspace', 'echo cleanup', undefined);
+    expect(provider.cleanup).toHaveBeenCalledWith('/workspace');
+
+    const trial = report.trials[0];
+    const cleanupLog = trial.session_log.find(l => l.type === 'trial_cleanup');
+    expect(cleanupLog).toBeTruthy();
+    expect(cleanupLog?.command).toBe('echo cleanup');
+  });
+
+  it('executes and logs trialConfig.setup', async () => {
+    const provider = makeMockProvider();
+    const agent = makeMockAgent();
+    const opts = makeEvalOpts({
+      trialConfig: {
+        setup: 'echo setup'
+      }
+    } as any);
+
+    const gradersModule = await import('../src/graders/index');
+    vi.spyOn(gradersModule, 'getGrader').mockReturnValue({
+      grade: vi.fn().mockResolvedValue({
+        grader_type: 'deterministic', score: 1.0, weight: 1.0, details: 'ok',
+      }),
+    });
+
+    const runner = new EvalRunner(provider);
+    const report = await runner.runEval(agent, '/task', [], opts, 1);
+
+    expect(provider.runCommand).toHaveBeenCalledWith('/workspace', 'echo setup', undefined);
+
+    const trial = report.trials[0];
+    const setupLog = trial.session_log.find(l => l.type === 'trial_setup');
+    expect(setupLog).toBeTruthy();
+    expect(setupLog?.command).toBe('echo setup');
+  });
 });

--- a/tests/evalRunner.test.ts
+++ b/tests/evalRunner.test.ts
@@ -338,7 +338,7 @@ describe('EvalRunner', () => {
     const runner = new EvalRunner(provider);
     const report = await runner.runEval(agent, '/task', [], opts, 1);
 
-    expect(provider.runCommand).toHaveBeenCalledWith('/workspace', 'echo cleanup', undefined);
+    expect(provider.runCommand).toHaveBeenCalledWith('/workspace', 'echo cleanup', {});
     expect(provider.cleanup).toHaveBeenCalledWith('/workspace');
 
     const trial = report.trials[0];
@@ -366,7 +366,7 @@ describe('EvalRunner', () => {
     const runner = new EvalRunner(provider);
     const report = await runner.runEval(agent, '/task', [], opts, 1);
 
-    expect(provider.runCommand).toHaveBeenCalledWith('/workspace', 'echo setup', undefined);
+    expect(provider.runCommand).toHaveBeenCalledWith('/workspace', 'echo setup', {});
 
     const trial = report.trials[0];
     const setupLog = trial.session_log.find(l => l.type === 'trial_setup');

--- a/tests/providers.local.test.ts
+++ b/tests/providers.local.test.ts
@@ -32,7 +32,7 @@ describe('LocalProvider', () => {
         environment: { build_timeout_sec: 180, cpus: 2, memory_mb: 2048, storage_mb: 500 },
       };
 
-      const workspace = await provider.setup(taskDir, [], taskConfig);
+      const workspace = await provider.setup(taskDir, [], taskConfig as any);
       tempDirs.push(workspace);
 
       expect(workspace).toContain('skillgrade-');
@@ -56,7 +56,7 @@ describe('LocalProvider', () => {
         environment: { build_timeout_sec: 180, cpus: 2, memory_mb: 2048, storage_mb: 500 },
       };
 
-      const workspace = await provider.setup(taskDir, [skillDir], taskConfig);
+      const workspace = await provider.setup(taskDir, [skillDir], taskConfig as any);
       tempDirs.push(workspace);
 
       const skillName = path.basename(skillDir);
@@ -67,6 +67,28 @@ describe('LocalProvider', () => {
       // Check Claude discovery path
       const claudePath = path.join(workspace, '.claude', 'skills', skillName, 'SKILL.md');
       expect(await fsExtra.pathExists(claudePath)).toBe(true);
+    });
+
+    it('cleans up temp directory if trialSetup fails', async () => {
+      const taskDir = path.join(os.tmpdir(), `skillgrade-test-task-${Date.now()}`);
+      await fsExtra.ensureDir(taskDir);
+      tempDirs.push(taskDir);
+
+      const taskConfig = {
+        version: '1',
+        graders: [],
+        agent: { timeout_sec: 300 },
+        environment: { cpus: 2, memory_mb: 2048 },
+        trialSetup: 'false',
+      };
+
+      const spyCleanup = vi.spyOn(provider, 'cleanup');
+
+      await expect(provider.setup(taskDir, [], taskConfig as any)).rejects.toThrow('Per-trial setup failed');
+
+      expect(spyCleanup).toHaveBeenCalled();
+      const calledWithPath = spyCleanup.mock.calls[0][0];
+      expect(await fsExtra.pathExists(calledWithPath)).toBe(false);
     });
   });
 

--- a/tests/providers.local.test.ts
+++ b/tests/providers.local.test.ts
@@ -8,8 +8,19 @@ import { LocalProvider } from '../src/providers/local';
 describe('LocalProvider', () => {
   const provider = new LocalProvider();
   let tempDirs: string[] = [];
+  let originalHome: string | undefined;
+  let mockHome: string;
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    mockHome = path.join(os.tmpdir(), `skillgrade-mock-home-${Date.now()}`);
+    await fsExtra.ensureDir(mockHome);
+    process.env.HOME = mockHome;
+    tempDirs.push(mockHome);
+  });
 
   afterEach(async () => {
+    process.env.HOME = originalHome;
     for (const dir of tempDirs) {
       try { await fsExtra.remove(dir); } catch {}
     }
@@ -61,11 +72,11 @@ describe('LocalProvider', () => {
 
       const skillName = path.basename(skillDir);
       // Check Gemini discovery path
-      const geminiPath = path.join(workspace, '.agents', 'skills', skillName, 'SKILL.md');
+      const geminiPath = path.join(mockHome, '.agents', 'skills', skillName, 'SKILL.md');
       expect(await fsExtra.pathExists(geminiPath)).toBe(true);
 
       // Check Claude discovery path
-      const claudePath = path.join(workspace, '.claude', 'skills', skillName, 'SKILL.md');
+      const claudePath = path.join(mockHome, '.claude', 'skills', skillName, 'SKILL.md');
       expect(await fsExtra.pathExists(claudePath)).toBe(true);
     });
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "tests/**/*.ts",
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
This is useful for putting the agent in a directory such as a cloned source repository.

The main challenge here is that previous the assumption of the agent running from /workspace meant that the skills could simply be added to /workspace/.agent/skills. Not all agents (*cough* gemini CLI) support looking in parent directories for skills and so if we clone to /workspace/source-repo, and run the agent from there, the skills will not always be found. The solution I went with is using $HOME/.agent/skills, which seems to be supported across agents. It has the downside that the 'local' provider will now clutter the user's actual $HOME/.agent/skills directory, but since we are only using the docker provider right now I think this is acceptable.