### PR TITLE
fix(codex): use exec subcommand for non-interactive evaluation

### DIFF
--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -1,22 +1,159 @@
-import { BaseAgent, CommandResult } from '../types';
+import { BaseAgent, CommandResult, AgentResult, SkillTriggerInfo } from '../types';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Parse --json JSONL output from Codex CLI to extract structured info.
+ *
+ * JSONL events of interest:
+ *   - type=item.completed, item.type="command_execution" → tool/command usage
+ *   - type=item.completed, item.type="agent_message"     → agent text output
+ *   - type=turn.completed, usage                         → token counts
+ */
+function parseCodexJsonOutput(rawOutput: string): AgentResult {
+    const lines = rawOutput.split('\n').filter(l => l.trim());
+    const toolsUsed = new Set<string>();
+    const skillsTriggered: SkillTriggerInfo[] = [];
+    const seenSkills = new Set<string>();
+    const messageParts: string[] = [];
+
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let numTurns = 0;
+
+    for (const line of lines) {
+        let event: any;
+        try {
+            event = JSON.parse(line);
+        } catch {
+            continue;
+        }
+
+        if (event.type === 'item.completed' && event.item) {
+            const item = event.item;
+
+            // Agent text message
+            if (item.type === 'agent_message' && item.text) {
+                messageParts.push(item.text);
+            }
+
+            // Command execution → record as tool usage
+            if (item.type === 'command_execution') {
+                toolsUsed.add('command_execution');
+
+                // Detect skill file reads from commands
+                const cmd: string = item.command || '';
+                const skillMatch = cmd.match(
+                    /(?:\.claude\/skills|\.agents\/skills|\.codefuse\/fuse\/skills)\/([^/\s]+)/
+                );
+                if (skillMatch) {
+                    const skillName = skillMatch[1];
+                    if (!seenSkills.has(`cmd:${skillName}`)) {
+                        seenSkills.add(`cmd:${skillName}`);
+                        skillsTriggered.push({
+                            name: skillName,
+                            source: 'file_read',
+                            timestamp: new Date().toISOString(),
+                            details: `Command referenced skill: ${cmd}`,
+                        });
+                    }
+                }
+            }
+
+            // Function call (if Codex supports tool_use style items in future)
+            if (item.type === 'tool_use' || item.type === 'function_call') {
+                const toolName = item.name || item.function?.name || 'unknown';
+                toolsUsed.add(toolName);
+            }
+        }
+
+        // Token usage from turn completion
+        if (event.type === 'turn.completed' && event.usage) {
+            numTurns++;
+            inputTokens += event.usage.input_tokens || 0;
+            outputTokens += event.usage.output_tokens || 0;
+        }
+    }
+
+    const finalOutput = messageParts.join('\n');
+
+    return {
+        output: finalOutput,
+        skills_triggered: skillsTriggered,
+        tools_used: Array.from(toolsUsed),
+        num_turns: numTurns || undefined,
+    };
+}
 
 export class CodexAgent extends BaseAgent {
+    /**
+     * Read API keys from ~/.codex/auth.json
+     * Returns environment variables to inject for codex CLI
+     */
+    private getCodexEnvVars(): Record<string, string> {
+        const authPath = path.join(os.homedir(), '.codex', 'auth.json');
+        const envVars: Record<string, string> = {};
+
+        try {
+            if (fs.existsSync(authPath)) {
+                const authContent = fs.readFileSync(authPath, 'utf-8');
+                const auth = JSON.parse(authContent);
+
+                // Map auth.json keys to environment variables
+                if (auth.OPENAI_API_KEY) {
+                    envVars.OPENAI_API_KEY = auth.OPENAI_API_KEY;
+                }
+                if (auth.ZENMUX_API_KEY) {
+                    envVars.ZENMUX_API_KEY = auth.ZENMUX_API_KEY;
+                }
+                // Also check for other common API key formats
+                for (const [key, value] of Object.entries(auth)) {
+                    if (key.endsWith('_API_KEY') && typeof value === 'string') {
+                        envVars[key] = value;
+                    }
+                }
+            }
+        } catch (e) {
+            // Ignore errors - auth.json may not exist or be malformed
+        }
+
+        return envVars;
+    }
+
     async run(
         instruction: string,
         _workspacePath: string,
-        runCommand: (cmd: string) => Promise<CommandResult>
-    ): Promise<string> {
+        runCommand: (cmd: string, env?: Record<string, string>) => Promise<CommandResult>
+    ): Promise<AgentResult> {
         // Write instruction to a temp file to avoid shell escaping issues with long prompts
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
-        const command = `codex --approval-mode full-auto "$(cat /tmp/.prompt.md)"`;
-        const result = await runCommand(command);
+        // Get API keys from auth.json
+        const envVars = this.getCodexEnvVars();
+
+        // Use --json for structured JSONL output, --ephemeral to avoid writing session files
+        // codex exec runs non-interactively; --full-auto enables sandboxed auto-execution
+        // --skip-git-repo-check allows running in non-git temp directories
+        const command = `cat /tmp/.prompt.md | codex exec --full-auto --skip-git-repo-check --json --ephemeral`;
+        const result = await runCommand(command, Object.keys(envVars).length > 0 ? envVars : undefined);
 
         if (result.exitCode !== 0) {
             console.error('CodexAgent: Codex CLI failed to execute correctly.');
         }
 
-        return result.stdout + '\n' + result.stderr;
+        // Parse JSONL events to extract structured info
+        const agentResult = parseCodexJsonOutput(result.stdout);
+        agentResult.raw_output = result.stdout.length > 256 * 1024
+            ? result.stdout.slice(0, 256 * 1024) + '\n... [truncated]'
+            : result.stdout;
+
+        // Fallback: if parsing didn't extract any output, use raw stdout+stderr
+        if (!agentResult.output) {
+            agentResult.output = result.stdout + '\n' + result.stderr;
+        }
+
+        return agentResult;
     }
 }

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import {
     BaseAgent, EnvironmentProvider,
-    LogEntry, TrialResult, EvalReport, GraderResult
+    LogEntry, TrialResult, EvalReport, GraderResult, AgentResult
 } from './types';
 import { ResolvedGrader } from './core/config.types';
 import { getGrader } from './graders';
@@ -45,6 +45,18 @@ function calculatePassPowK(n: number, c: number, k: number): number {
 /** Estimate token count from text (~4 chars per token) */
 function estimateTokens(text: string): number {
     return Math.ceil(text.length / 4);
+}
+
+/** Normalize agent output to AgentResult format */
+function normalizeAgentOutput(raw: string | AgentResult): AgentResult {
+    if (typeof raw === 'string') {
+        return {
+            output: raw,
+            skills_triggered: [],
+            tools_used: [],
+        };
+    }
+    return raw;
 }
 
 /** Options for running an eval */
@@ -198,16 +210,17 @@ export class EvalRunner {
             };
 
             const agentTimeoutMs = opts.timeoutSec * 1000;
-            const agentLogs = await withTimeout(
+            const agentRaw = await withTimeout(
                 agent.run(instruction, workspace, loggedRunCommand),
                 agentTimeoutMs,
                 `Agent (limit: ${opts.timeoutSec}s)`
             );
+            const agentResult = normalizeAgentOutput(agentRaw);
 
             sessionLog.push({
                 type: 'agent_result',
                 timestamp: this.timestamp(),
-                output: agentLogs
+                output: agentResult.output
             });
 
             // Run all graders

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,28 @@ export interface TrialResult {
     input_tokens: number;     // estimated from instruction length
     output_tokens: number;    // estimated from agent output
     session_log: LogEntry[];
+    // Skill trigger tracking
+    skills_triggered?: SkillTriggerInfo[];  // List of triggered skills
+    tools_used?: string[];                  // List of tools used
+}
+
+/** Skill trigger information during agent execution */
+export interface SkillTriggerInfo {
+    name: string;               // Skill name
+    source: 'tool_use' | 'file_read' | 'init_list';  // Detection source
+    timestamp?: string;         // Trigger timestamp
+    details?: string;           // Additional details (e.g., file path read)
+}
+
+/** Structured agent execution result */
+export interface AgentResult {
+    output: string;                         // Final text output from agent
+    raw_output?: string;                    // Raw CLI output
+    skills_triggered: SkillTriggerInfo[];   // List of triggered skills
+    tools_used: string[];                   // List of tools used (e.g., Read, Bash, Edit)
+    num_turns?: number;                     // Number of API interaction turns
+    duration_api_ms?: number;               // API duration in milliseconds
+    cost_usd?: number;                      // Cost in USD
 }
 
 export interface EvalReport {
@@ -56,8 +78,8 @@ export abstract class BaseAgent {
     abstract run(
         instruction: string,
         workspacePath: string,
-        runCommand: (cmd: string) => Promise<CommandResult>
-    ): Promise<string>;
+        runCommand: (cmd: string, env?: Record<string, string>) => Promise<CommandResult>
+    ): Promise<string | AgentResult>;
 }
 
 /** Options passed to environment providers for setup */

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -1,10 +1,18 @@
 import { BaseAgent } from '../src/types';
 import { LocalProvider } from '../src/providers/local';
 import { DockerProvider } from '../src/providers/docker';
-import { EvalRunner, loadTaskConfig } from '../src/evalRunner';
+import { EvalRunner, EvalRunOptions } from '../src/evalRunner';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import * as fs from 'fs-extra';
+
+// Default eval options for testing
+const DEFAULT_EVAL_OPTS: EvalRunOptions = {
+    instruction: 'Fix linting issues',
+    graders: [{ type: 'deterministic', weight: 1.0 }],
+    timeoutSec: 300,
+    environment: { cpus: 2, memory_mb: 2048 },
+};
 
 async function runTest(useDocker: boolean, numTrials: number = 1, logDir?: string) {
     console.log(`\n--- Testing with ${useDocker ? 'Docker' : 'Local'} Provider (${numTrials} trials, logDir: ${logDir || 'none'}) ---`);
@@ -25,7 +33,7 @@ async function runTest(useDocker: boolean, numTrials: number = 1, logDir?: strin
     } as BaseAgent;
 
     const taskPath = path.join(__dirname, '..', 'tasks', 'superlint_demo');
-    const report = await runner.runEval(solvingAgent, taskPath, [], numTrials);
+    const report = await runner.runEval(solvingAgent, taskPath, [], DEFAULT_EVAL_OPTS, numTrials);
 
     console.log('Eval Report Summary:');
     console.log(`Task: ${report.task}`);
@@ -127,6 +135,7 @@ async function main() {
             secretAgent,
             path.join(__dirname, '..', 'tasks', 'superlint_demo'),
             [],
+            DEFAULT_EVAL_OPTS,
             1,
             { MY_SECRET: 'SUPER_SECRET_KEY_12345' }
         );

--- a/tests/commands.run.test.ts
+++ b/tests/commands.run.test.ts
@@ -14,7 +14,33 @@ vi.mock('fs-extra', () => ({
 
 import * as fs from 'fs-extra';
 import { ResolvedTask } from '../src/core/config.types';
-import { TaskConfig } from '../src/types';
+
+// TaskConfig type for testing (not exported from types)
+interface TaskConfig {
+  version: string;
+  metadata: {
+    author_name: string;
+    author_email: string;
+    difficulty: string;
+    category: string;
+    tags: string[];
+  };
+  graders: Array<{
+    type: 'deterministic' | 'llm_rubric';
+    command?: string;
+    rubric?: string;
+    weight: number;
+  }>;
+  agent: {
+    timeout_sec: number;
+  };
+  environment: {
+    build_timeout_sec: number;
+    cpus: number;
+    memory_mb: number;
+    storage_mb: number;
+  };
+}
 
 const mockPathExists = vi.mocked(fs.pathExists);
 const mockEnsureDir = vi.mocked(fs.ensureDir);
@@ -65,6 +91,7 @@ describe('resolvedToTaskConfig', () => {
       trials: 5,
       timeout: 300,
       docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
     };
 
     const config = resolvedToTaskConfig(resolved);
@@ -84,6 +111,7 @@ describe('resolvedToTaskConfig', () => {
       trials: 5,
       timeout: 300,
       docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
     };
 
     const config = resolvedToTaskConfig(resolved);
@@ -103,6 +131,7 @@ describe('resolvedToTaskConfig', () => {
       trials: 5,
       timeout: 600,
       docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
     };
 
     const config = resolvedToTaskConfig(resolved);
@@ -120,6 +149,7 @@ describe('resolvedToTaskConfig', () => {
       trials: 5,
       timeout: 300,
       docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
     };
 
     const config = resolvedToTaskConfig(resolved);
@@ -143,6 +173,7 @@ describe('resolvedToTaskConfig', () => {
       trials: 5,
       timeout: 300,
       docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
     };
 
     const config = resolvedToTaskConfig(resolved);
@@ -162,6 +193,7 @@ describe('resolvedToTaskConfig', () => {
       trials: 5,
       timeout: 300,
       docker: { base: 'node:20-slim' },
+      environment: { cpus: 2, memory_mb: 2048 },
     };
 
     const config = resolvedToTaskConfig(resolved);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -217,6 +217,7 @@ describe('resolveTask', () => {
     timeout: 300,
     threshold: 0.8,
     docker: { base: 'node:20-slim' },
+    environment: { cpus: 2, memory_mb: 2048 },
   };
 
   it('applies defaults when task has no overrides', async () => {

--- a/tests/providers.local.test.ts
+++ b/tests/providers.local.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as fsReal from 'fs';
 import * as fsExtra from 'fs-extra';
 import { LocalProvider } from '../src/providers/local';
+import { EnvironmentSetupOpts } from '../src/types';
 
 describe('LocalProvider', () => {
   const provider = new LocalProvider();
@@ -24,15 +25,12 @@ describe('LocalProvider', () => {
       await fsExtra.writeFile(path.join(taskDir, 'task.toml'), 'version = "1"');
       tempDirs.push(taskDir);
 
-      const taskConfig = {
-        version: '1',
-        metadata: { author_name: '', author_email: '', difficulty: 'medium', category: '', tags: [] },
-        graders: [],
-        agent: { timeout_sec: 300 },
-        environment: { build_timeout_sec: 180, cpus: 2, memory_mb: 2048, storage_mb: 500 },
+      const setupOpts: EnvironmentSetupOpts = {
+        timeoutSec: 300,
+        environment: { cpus: 2, memory_mb: 2048 },
       };
 
-      const workspace = await provider.setup(taskDir, [], taskConfig);
+      const workspace = await provider.setup(taskDir, [], setupOpts);
       tempDirs.push(workspace);
 
       expect(workspace).toContain('skillgrade-');
@@ -48,15 +46,12 @@ describe('LocalProvider', () => {
       await fsExtra.writeFile(path.join(skillDir, 'SKILL.md'), '# Test Skill');
       tempDirs.push(taskDir, skillDir);
 
-      const taskConfig = {
-        version: '1',
-        metadata: { author_name: '', author_email: '', difficulty: 'medium', category: '', tags: [] },
-        graders: [],
-        agent: { timeout_sec: 300 },
-        environment: { build_timeout_sec: 180, cpus: 2, memory_mb: 2048, storage_mb: 500 },
+      const setupOpts: EnvironmentSetupOpts = {
+        timeoutSec: 300,
+        environment: { cpus: 2, memory_mb: 2048 },
       };
 
-      const workspace = await provider.setup(taskDir, [skillDir], taskConfig);
+      const workspace = await provider.setup(taskDir, [skillDir], setupOpts);
       tempDirs.push(workspace);
 
       const skillName = path.basename(skillDir);


### PR DESCRIPTION
- Use `codex exec --full-auto --skip-git-repo-check --json --ephemeral` instead of interactive mode for automated evaluation
- Add parseCodexJsonOutput to extract skills_triggered, tools_used, num_turns from JSONL output
- Add getCodexEnvVars to load API keys from ~/.codex/auth.json
- Add SkillTriggerInfo and AgentResult interfaces for structured agent output
- Modify BaseAgent.run signature to return string | AgentResult and accept optional env parameter
- Add normalizeAgentOutput helper in evalRunner.ts for backward compatibility
- Fix test files to match updated type definitions