### PR TITLE
fix: add Agent Client Protocol (ACP) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Reports are saved to `$TMPDIR/skillgrade/<skill-name>/results/`. Override with `
 | `--grader=TYPE` | Run only graders of a type (`deterministic` or `llm_rubric`) |
 | `--trials=N` | Override trial count |
 | `--parallel=N` | Run trials concurrently |
-| `--agent=gemini\|claude\|codex` | Override agent (default: auto-detect from API key) |
+| `--agent=gemini\|claude\|codex\|acp` | Override agent (default: auto-detect from API key) |
 | `--provider=docker\|local` | Override provider |
+| `--acp-command=CMD` | ACP agent command (e.g., `gemini --acp`) |
 | `--output=DIR` | Output directory (default: `$TMPDIR/skillgrade`) |
 | `--validate` | Verify graders using reference solutions |
 | `--ci` | CI mode: exit non-zero if below threshold |
@@ -76,12 +77,16 @@ version: "1"
 # skill: path/to/my-skill
 
 defaults:
-  agent: gemini          # gemini | claude | codex
+  agent: gemini          # gemini | claude | codex | acp
   provider: docker       # docker | local
   trials: 5
   timeout: 300           # seconds
   threshold: 0.8         # for --ci mode
   grader_model: gemini-3-flash-preview  # default LLM grader model
+  acp:                   # ACP agent configuration (optional)
+    command: gemini --acp  # command to start ACP-compatible agent
+    env:                  # optional environment variables
+      DEBUG: "1"
   docker:
     base: node:20-slim
     setup: |             # extra commands run during image build
@@ -231,6 +236,51 @@ Exits with code 1 if pass rate falls below `--threshold` (default: 0.8).
 | `OPENAI_API_KEY` | Agent execution (Codex), `skillgrade init` |
 
 Variables are also loaded from `.env` in the skill directory. Shell values override `.env`. All values are **redacted** from persisted session logs.
+
+## ACP Agent
+
+[Agent Client Protocol (ACP)](https://agentclientprotocol.com/) is an open protocol that standardizes communication between AI coding agents and clients. Using an ACP-compatible agent allows you to evaluate skills without managing API keys directly.
+
+### Quick Start
+
+```bash
+# Use Gemini CLI in ACP mode (requires gemini CLI installed)
+skillgrade --agent=acp --acp-command="gemini --acp"
+
+# Or configure in eval.yaml
+```
+
+```yaml
+defaults:
+  agent: acp
+  acp:
+    command: gemini --acp
+```
+
+### ACP-Compatible Agents
+
+Any agent that supports the ACP protocol can be used:
+
+| Agent | Command |
+|-------|---------|
+| Gemini CLI | `gemini --acp` |
+| Other ACP agents | Check agent documentation |
+
+### How It Works
+
+1. skillgrade starts the ACP agent as a subprocess
+2. Communication happens via JSON-RPC 2.0 over stdio
+3. No API key required — authentication is handled by the ACP agent
+4. Works best with `--provider=local` since the ACP agent needs to be available in your environment
+
+### CLI Options
+
+| Flag | Description |
+|------|-------------|
+| `--agent=acp` | Use ACP-compatible agent |
+| `--acp-command=CMD` | Command to start the ACP agent |
+
+The `--acp-command` can also be set in `eval.yaml` under `defaults.acp.command`.
 
 ## Best Practices
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.19.0",
     "dockerode": "^4.0.9",
     "fs-extra": "^11.3.3",
     "js-yaml": "^4.1.1",

--- a/src/agents/acp.ts
+++ b/src/agents/acp.ts
@@ -1,0 +1,281 @@
+/**
+ * ACP (Agent Client Protocol) Agent Implementation
+ *
+ * This agent communicates with ACP-compatible agents (like Gemini CLI with --acp flag)
+ * using JSON-RPC 2.0 over stdio. This allows using any ACP-compatible agent without
+ * requiring direct API key configuration.
+ *
+ * @see https://agentclientprotocol.com/
+ */
+import { spawn, ChildProcess } from 'child_process';
+import { BaseAgent, CommandResult } from '../types';
+import * as acp from '@agentclientprotocol/sdk';
+
+/**
+ * Configuration for ACP agent
+ */
+export interface AcpAgentConfig {
+    /** Command to start the ACP agent (e.g., "gemini --acp") */
+    command: string;
+    /** Optional environment variables */
+    env?: Record<string, string>;
+    /** Optional API key for authentication */
+    apiKey?: string;
+    /** Timeout in milliseconds for agent operations (default: 300000 = 5 min) */
+    timeout?: number;
+}
+
+/**
+ * ACP Agent implementation that communicates with ACP-compatible agents.
+ *
+ * The Agent Client Protocol (ACP) is a standardized protocol for communication
+ * between code editors/clients and AI coding agents. It uses JSON-RPC 2.0
+ * over stdio for transport.
+ *
+ * Example usage:
+ * - Gemini CLI: `gemini --acp`
+ * - Any ACP-compatible agent
+ */
+export class AcpAgent extends BaseAgent {
+    private config: AcpAgentConfig;
+    private process: ChildProcess | null = null;
+    private connection: acp.ClientSideConnection | null = null;
+    private sessionId: string | null = null;
+    private sessionOutputs: string[] = [];
+
+    constructor(config: AcpAgentConfig) {
+        super();
+        this.config = {
+            timeout: 300000,
+            ...config,
+        };
+    }
+
+    /**
+     * Run an instruction using the ACP agent.
+     */
+    async run(
+        instruction: string,
+        workspacePath: string,
+        runCommand: (cmd: string) => Promise<CommandResult>
+    ): Promise<string> {
+        try {
+            // Initialize connection if not already established
+            if (!this.connection) {
+                await this.initialize(workspacePath);
+            }
+
+            if (!this.sessionId) {
+                throw new Error('No active session. Failed to create session.');
+            }
+
+            // Clear session outputs
+            this.sessionOutputs = [];
+
+            // Send the prompt - prompt is an array of ContentBlock
+            const promptContent = [
+                { type: 'text', text: instruction },
+            ];
+
+            const response = await this.withTimeout(
+                this.connection!.prompt({
+                    sessionId: this.sessionId,
+                    prompt: promptContent as acp.ContentBlock[],
+                }),
+                this.config.timeout!,
+                'Prompt execution'
+            );
+
+            // Format response
+            const outputs = [...this.sessionOutputs];
+            if (response.stopReason) {
+                outputs.push(`\n[Agent finished: ${response.stopReason}]`);
+            }
+
+            return outputs.join('\n').trim() || 'Agent completed without output.';
+
+        } catch (error) {
+            const errorMsg = error instanceof Error ? error.message : String(error);
+            return `ACP Agent error: ${errorMsg}`;
+        }
+    }
+
+    /**
+     * Initialize the ACP connection and create a session.
+     */
+    private async initialize(cwd: string): Promise<void> {
+        // Parse command into parts
+        const parts = this.config.command.split(' ');
+        const command = parts[0];
+        const args = parts.slice(1);
+
+        // Spawn the ACP agent process
+        this.process = spawn(command, args, {
+            cwd,
+            env: { ...process.env, ...this.config.env },
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+
+        if (!this.process.stdin || !this.process.stdout) {
+            throw new Error('Failed to create stdio streams for ACP process');
+        }
+
+        // Create the ACP stream from stdio
+        // Convert Node.js streams to Web streams
+        const stdoutWeb = this.process.stdout as unknown as WritableStream;
+        const stdinWeb = this.process.stdin as unknown as ReadableStream<Uint8Array>;
+        const stream = acp.ndJsonStream(stdoutWeb, stdinWeb);
+
+        // Create client handler
+        const clientHandler = this.createClientHandler();
+
+        // Create client-side connection
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.connection = new acp.ClientSideConnection(clientHandler as any, stream);
+
+        // Initialize the connection
+        const initResponse = await this.withTimeout(
+            this.connection.initialize({
+                protocolVersion: acp.PROTOCOL_VERSION,
+                clientCapabilities: {
+                    fs: {
+                        readTextFile: true,
+                        writeTextFile: true,
+                    },
+                },
+            }),
+            30000,
+            'ACP initialization'
+        );
+
+        // Authenticate if we have an API key
+        if (this.config.apiKey) {
+            // Find the API key auth method
+            const authMethods = initResponse.authMethods || [];
+            const apiKeyMethod = authMethods.find(
+                (m) => m.id === 'use_gemini' || m.id === 'api_key'
+            );
+
+            if (apiKeyMethod) {
+                const authRequest = {
+                    methodId: apiKeyMethod.id,
+                    _meta: {
+                        'api-key': this.config.apiKey,
+                    },
+                };
+
+                await this.withTimeout(
+                    this.connection!.authenticate(authRequest as acp.AuthenticateRequest),
+                    60000,
+                    'ACP authentication'
+                );
+            }
+        }
+
+        // Create a new session
+        const sessionResponse = await this.withTimeout(
+            this.connection.newSession({
+                cwd,
+                mcpServers: [],
+            }),
+            30000,
+            'ACP session creation'
+        );
+
+        this.sessionId = sessionResponse.sessionId;
+    }
+
+    /**
+     * Create the client handler for handling agent requests.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private createClientHandler(): any {
+        const self = this;
+
+        return {
+            // Handle permission requests from agent (auto-approve for evaluation)
+            async requestPermission(params: acp.RequestPermissionRequest): Promise<acp.RequestPermissionResponse> {
+                // Auto-approve for evaluation context by selecting the first option
+                const options = params.options || [];
+                if (options.length > 0) {
+                    // Select the first option (usually "allow_once" or similar)
+                    const response = {
+                        outcome: 'selected',
+                        optionId: options[0].optionId,
+                    };
+                    return response as unknown as acp.RequestPermissionResponse;
+                }
+                // If no options, cancel
+                return { outcome: 'cancelled' } as unknown as acp.RequestPermissionResponse;
+            },
+
+            // Handle session updates from agent
+            async sessionUpdate(params: acp.SessionNotification): Promise<void> {
+                // Collect text content from update
+                self.handleSessionUpdate(params.update);
+            },
+
+            // File system operations (not supported in evaluation mode)
+            async readTextFile(params: acp.ReadTextFileRequest): Promise<acp.ReadTextFileResponse> {
+                throw new Error('File system access not supported in ACP evaluation mode');
+            },
+
+            async writeTextFile(params: acp.WriteTextFileRequest): Promise<acp.WriteTextFileResponse> {
+                throw new Error('File system access not supported in ACP evaluation mode');
+            },
+        };
+    }
+
+    /**
+     * Handle session updates from the agent.
+     */
+    private handleSessionUpdate(update: acp.SessionUpdate): void {
+        // Check for text content
+        const updateRecord = update as Record<string, unknown>;
+        if ('content' in updateRecord && updateRecord.content) {
+            const content = updateRecord.content as Record<string, unknown>;
+            if ('text' in content && content.text) {
+                this.sessionOutputs.push(String(content.text));
+            }
+        }
+        // Check for tool call info
+        if ('name' in updateRecord && updateRecord.name) {
+            const status = 'status' in updateRecord ? updateRecord.status : 'unknown';
+            this.sessionOutputs.push(`[Tool: ${updateRecord.name} - ${status}]`);
+        }
+    }
+
+    /**
+     * Wrap a promise with a timeout.
+     */
+    private withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                reject(new Error(`${label} timed out after ${timeoutMs / 1000}s`));
+            }, timeoutMs);
+
+            promise.then(
+                (result) => {
+                    clearTimeout(timer);
+                    resolve(result);
+                },
+                (error) => {
+                    clearTimeout(timer);
+                    reject(error);
+                }
+            );
+        });
+    }
+
+    /**
+     * Cleanup the ACP connection and process.
+     */
+    async cleanup(): Promise<void> {
+        if (this.process) {
+            this.process.kill();
+            this.process = null;
+        }
+        this.connection = null;
+        this.sessionId = null;
+    }
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -5,17 +5,27 @@
  *   - gemini: Google Gemini CLI
  *   - claude: Anthropic Claude Code CLI
  *   - codex: OpenAI Codex CLI
+ *   - acp: Agent Client Protocol compatible agents
  */
 import { BaseAgent } from '../types';
 import { GeminiAgent } from './gemini';
 import { ClaudeAgent } from './claude';
 import { CodexAgent } from './codex';
+import { AcpAgent, AcpAgentConfig } from './acp';
+
+/** Configuration for agent creation */
+export interface AgentConfig {
+    /** ACP-specific configuration */
+    acp?: AcpAgentConfig;
+}
 
 /** Registry of available agent implementations */
 const AGENT_REGISTRY: Record<string, () => BaseAgent> = {
     gemini: () => new GeminiAgent(),
     claude: () => new ClaudeAgent(),
     codex: () => new CodexAgent(),
+    // ACP agent requires config, registered as placeholder
+    acp: () => new AcpAgent({ command: 'gemini --acp' }),
 };
 
 /** Get the list of supported agent names */
@@ -24,7 +34,12 @@ export function getAgentNames(): string[] {
 }
 
 /** Create an agent instance by name. Throws if the name is unknown. */
-export function createAgent(name: string): BaseAgent {
+export function createAgent(name: string, config?: AgentConfig): BaseAgent {
+    // Handle ACP agent with custom configuration
+    if (name === 'acp' && config?.acp) {
+        return new AcpAgent(config.acp);
+    }
+
     const factory = AGENT_REGISTRY[name];
     if (!factory) {
         const available = getAgentNames().join(', ');

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -11,7 +11,7 @@ import { detectSkills } from '../core/skills';
 import { DockerProvider } from '../providers/docker';
 import { LocalProvider } from '../providers/local';
 import { EvalRunner, EvalRunOptions } from '../evalRunner';
-import { createAgent } from '../agents/registry';
+import { createAgent, AgentConfig } from '../agents/registry';
 import { BaseAgent, EvalReport } from '../types';
 import { ResolvedTask } from '../core/config.types';
 import { parseEnvFile } from '../utils/env';
@@ -25,10 +25,11 @@ interface RunOptions {
     ci?: boolean;
     threshold?: number;
     preset?: 'smoke' | 'reliable' | 'regression';
-    agent?: string;      // override agent (gemini|claude)
+    agent?: string;      // override agent (gemini|claude|codex|acp)
     provider?: string;   // override provider (docker|local)
     output?: string;     // output directory for reports and temp files
     grader?: string;     // filter graders by type (deterministic|llm_rubric)
+    acpCommand?: string; // ACP agent command (e.g., "gemini --acp")
 }
 
 async function loadEnvFile(filePath: string): Promise<Record<string, string>> {
@@ -138,6 +139,21 @@ export async function runEvals(dir: string, opts: RunOptions) {
         }
         const providerName = opts.provider || resolved.provider;
 
+        // Build agent config (for ACP agent)
+        const agentConfig: AgentConfig = {};
+        if (agentName === 'acp') {
+            // Use CLI flag > eval.yaml config > default
+            const acpCommand = opts.acpCommand || resolved.acp?.command;
+            if (!acpCommand) {
+                throw new Error('ACP agent requires a command. Specify via --acp-command or acp.command in eval.yaml');
+            }
+            agentConfig.acp = {
+                command: acpCommand,
+                env: resolved.acp?.env,
+                apiKey: env.GEMINI_API_KEY || env.ANTHROPIC_API_KEY || env.OPENAI_API_KEY,
+            };
+        }
+
         // Pick provider
         const provider = providerName === 'docker'
             ? new DockerProvider()
@@ -173,7 +189,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             if (!passed) allPassed = false;
         } else {
             // Normal eval mode
-            const agent = createAgent(agentName);
+            const agent = createAgent(agentName, agentConfig);
 
             header(resolved.name);
             console.log(`    ${fmt.dim('agent')} ${agentName}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
@@ -271,6 +287,12 @@ async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string, tmpDi
         dockerfileContent += `RUN npm install -g @anthropic-ai/claude-code\n\n`;
     } else if (resolved.agent === 'codex') {
         dockerfileContent += `RUN npm install -g @openai/codex\n\n`;
+    } else if (resolved.agent === 'acp') {
+        // For ACP agent, install gemini-cli as the default ACP-compatible agent
+        // Users can customize the command via acp.command in eval.yaml
+        // Note: ACP agent works best with --provider=local since it requires
+        // the ACP command to be available in the host environment
+        dockerfileContent += `RUN npm install -g @google/gemini-cli\n\n`;
     }
 
     // Docker setup commands

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,6 +11,7 @@ import {
     ResolvedGrader,
     WorkspaceMapping,
     EnvironmentConfig,
+    AcpConfig,
 } from './config.types';
 
 // We use a simple YAML parser — js-yaml is the standard
@@ -63,6 +64,19 @@ function validateConfig(raw: any): EvalConfig {
     }
 
     const version = raw.version || '1';
+
+    // Handle ACP config
+    let acp: AcpConfig | undefined;
+    if (raw.defaults?.acp) {
+        if (!raw.defaults.acp.command) {
+            throw new Error('eval.yaml: acp.command is required when using ACP agent');
+        }
+        acp = {
+            command: raw.defaults.acp.command,
+            env: raw.defaults.acp.env,
+        };
+    }
+
     const defaults: EvalDefaults = {
         ...DEFAULT_CONFIG,
         ...(raw.defaults || {}),
@@ -75,6 +89,11 @@ function validateConfig(raw: any): EvalConfig {
             ...(raw.defaults?.environment || {}),
         },
     };
+
+    // Add ACP config if present
+    if (acp) {
+        defaults.acp = acp;
+    }
 
     if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
         throw new Error('eval.yaml must have at least one task in the "tasks" array');
@@ -144,6 +163,7 @@ export async function resolveTask(
         ...(task.environment || {}),
     };
     const grader_model = task.grader_model || defaults.grader_model;
+    const acp = defaults.acp;  // ACP config is only at defaults level
 
     // Resolve instruction — could be inline text or file path
     const instruction = await resolveFileOrInline(task.instruction, baseDir);
@@ -183,6 +203,7 @@ export async function resolveTask(
         trials,
         timeout,
         grader_model,
+        acp,
         docker,
         environment,
     };

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -34,6 +34,14 @@ export interface EnvironmentConfig {
     memory_mb: number;
 }
 
+/** ACP (Agent Client Protocol) configuration */
+export interface AcpConfig {
+    /** Command to start the ACP agent (e.g., "gemini --acp") */
+    command: string;
+    /** Optional environment variables for the ACP process */
+    env?: Record<string, string>;
+}
+
 /** Single eval task */
 export interface EvalTaskConfig {
     name: string;
@@ -54,12 +62,13 @@ export interface EvalTaskConfig {
 
 /** Top-level defaults */
 export interface EvalDefaults {
-    agent: string;      // 'gemini' | 'claude' | 'codex'
+    agent: string;      // 'gemini' | 'claude' | 'codex' | 'acp'
     provider: string;   // 'docker' | 'local'
     trials: number;
     timeout: number;
     threshold: number;  // for --ci mode
     grader_model?: string;  // default LLM grader model
+    acp?: AcpConfig;    // ACP agent configuration
     docker: DockerConfig;
     environment: EnvironmentConfig;
 }
@@ -84,6 +93,7 @@ export interface ResolvedTask {
     trials: number;
     timeout: number;
     grader_model?: string;  // inherited default model for LLM graders
+    acp?: AcpConfig;        // ACP agent configuration
     docker: DockerConfig;
     environment: EnvironmentConfig;
 }

--- a/src/skillgrade.ts
+++ b/src/skillgrade.ts
@@ -102,6 +102,7 @@ async function main() {
         provider: getFlag('provider'),
         grader: getFlag('grader'),
         output: outputDir,
+        acpCommand: getFlag('acp-command'),
     });
 
     if (openPreview) {
@@ -129,8 +130,9 @@ function printHelp() {
     --grader=TYPE      Run only graders of this type (deterministic|llm_rubric)
     --trials=N         Override trial count (overrides preset)
     --parallel=N       Run trials concurrently
-    --agent=gemini|claude|codex   Override agent (default: auto-detect from API key)
+    --agent=gemini|claude|codex|acp   Override agent (default: auto-detect from API key)
     --provider=docker|local Override provider (default: docker)
+    --acp-command=CMD  ACP agent command (e.g., "gemini --acp")
     --output=DIR       Output directory for reports and temp files
                        Default: $TMPDIR/skillgrade
     --validate         Verify graders using reference solutions
@@ -146,6 +148,7 @@ function printHelp() {
     skillgrade --eval=fix-linting  # run a specific eval
     skillgrade --eval=foo,bar      # run multiple evals
     skillgrade --regression --ci   # CI regression with 30 trials
+    skillgrade --agent=acp --acp-command="gemini --acp"  # use ACP-compatible agent
     skillgrade preview browser     # open web UI
 `);
 }


### PR DESCRIPTION
Fixes #9 
Add support for ACP-compatible agents (like Gemini CLI with --acp flag), allowing users to run evaluations without directly managing API keys.

- Add AcpAgent class that communicates via JSON-RPC 2.0 over stdio
- Add @agentclientprotocol/sdk dependency
- Support --agent=acp and --acp-command CLI options
- Add acp config section in eval.yaml for persistent configuration
- Auto-approve permission requests for evaluation context
- Update README with ACP usage documentation