### PR TITLE
feat: add configurable grader provider support and custom base urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ defaults:
   timeout: 300           # seconds
   threshold: 0.8         # for --ci mode
   grader_model: gemini-3-flash-preview  # default LLM grader model
+  grader_provider: gemini               # default LLM grader provider: gemini | anthropic | openai
   acp:                   # ACP agent configuration (optional)
     command: gemini --acp  # command to start ACP-compatible agent
     env:                  # optional environment variables
@@ -123,6 +124,7 @@ tasks:
 
     # Per-task overrides (optional)
     agent: claude
+    grader_provider: anthropic   # override default LLM grader provider
     trials: 10
     timeout: 600
 ```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ tasks:
       - type: llm_rubric
         rubric: |
           Did the agent follow the check → fix → verify workflow?
+        provider: gemini                 # optional: gemini (default) | anthropic | openai
         model: gemini-2.0-flash          # optional model override
         weight: 0.3
 
@@ -194,10 +195,19 @@ Evaluates the agent's session transcript against qualitative criteria:
     Efficiency (0-0.5):
     - Completed in ≤5 commands?
   weight: 0.3
+  provider: gemini           # gemini (default) | anthropic | openai
   model: gemini-2.0-flash    # optional, auto-detected from API key
 ```
 
-Uses Gemini or Anthropic based on available API key. Override with the `model` field.
+The `provider` field selects which LLM API to call:
+
+| Provider   | API Key Env Var     | Base URL Env Var (optional) | Default Model              |
+|------------|---------------------|-----------------------------|----------------------------|
+| `gemini`   | `GEMINI_API_KEY`    | -                           | `gemini-3-flash-preview`   |
+| `anthropic`| `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL`        | `claude-sonnet-4-20250514` |
+| `openai`   | `OPENAI_API_KEY`    | `OPENAI_BASE_URL`           | `gpt-4o`                   |
+
+`ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` enable custom/self-hosted endpoints (Ollama, vLLM, etc.).
 
 ### Combining Graders
 
@@ -233,9 +243,11 @@ Exits with code 1 if pass rate falls below `--threshold` (default: 0.8).
 
 | Variable | Used by |
 |----------|---------|
-| `GEMINI_API_KEY` | Agent execution, LLM grading, `skillgrade init` |
-| `ANTHROPIC_API_KEY` | Agent execution, LLM grading, `skillgrade init` |
-| `OPENAI_API_KEY` | Agent execution (Codex), `skillgrade init` |
+| `GEMINI_API_KEY` | Agent execution, LLM grading (`provider: gemini`), `skillgrade init` |
+| `ANTHROPIC_API_KEY` | Agent execution, LLM grading (`provider: anthropic`), `skillgrade init` |
+| `OPENAI_API_KEY` | Agent execution (Codex), LLM grading (`provider: openai`), `skillgrade init` |
+| `ANTHROPIC_BASE_URL` | LLM grading (`provider: anthropic`) — custom Anthropic-compatible endpoint |
+| `OPENAI_BASE_URL` | LLM grading (`provider: openai`) — custom OpenAI-compatible endpoint (Ollama, vLLM, etc.) |
 
 Variables are also loaded from `.env` in the skill directory. Shell values override `.env`. All values are **redacted** from persisted session logs.
 

--- a/skills/skillgrade-graders/SKILL.md
+++ b/skills/skillgrade-graders/SKILL.md
@@ -42,7 +42,8 @@ description: Authors deterministic and LLM rubric graders for skillgrade evaluat
      rubric: |
        [rubric text or file path]
      weight: 0.3
-     model: gemini-2.0-flash  # optional, auto-detected from API key
+     provider: gemini               # optional: gemini (default) | anthropic | openai
+     model: gemini-3-flash-preview  # optional, each provider has a default model
    ```
 4. For long rubrics, store in a separate file and reference by path: `rubric: rubrics/quality.md`.
 
@@ -70,5 +71,6 @@ description: Authors deterministic and LLM rubric graders for skillgrade evaluat
 
 ## Error Handling
 * If a deterministic grader outputs non-JSON, ensure all `echo`/`console.log` statements except the final JSON result are redirected to stderr.
-* If an LLM rubric grader returns 0.00 with "No API key," set `GEMINI_API_KEY` or `ANTHROPIC_API_KEY` in the environment.
+* If an LLM rubric grader returns 0.00 with a missing API key message, set the appropriate key for your provider: `GEMINI_API_KEY` (provider: gemini), `ANTHROPIC_API_KEY` (provider: anthropic), or `OPENAI_API_KEY` (provider: openai).
+* To use a custom/self-hosted LLM endpoint, set `ANTHROPIC_BASE_URL` (for provider: anthropic) or `OPENAI_BASE_URL` (for provider: openai) — e.g. for Ollama or vLLM.
 * If scores are inconsistent across trials, reduce rubric ambiguity by adding concrete examples of passing and failing behavior.

--- a/skills/skillgrade-setup/references/eval-yaml-spec.md
+++ b/skills/skillgrade-setup/references/eval-yaml-spec.md
@@ -19,6 +19,7 @@ Configure shared settings for all tasks.
 | `timeout` | number | 300 | Seconds before agent timeout |
 | `threshold` | number | 0.8 | Pass rate threshold for `--ci` mode |
 | `grader_model` | string | auto-detect | Default LLM model for rubric graders |
+| `grader_provider` | string | `gemini` | Default LLM provider for rubric graders (`gemini`, `anthropic`, or `openai`) |
 
 ### defaults.docker
 

--- a/skills/skillgrade-setup/references/eval-yaml-spec.md
+++ b/skills/skillgrade-setup/references/eval-yaml-spec.md
@@ -64,7 +64,8 @@ Array of evaluation tasks. Each task has:
 | `run` | string | Deterministic only | Command to execute |
 | `setup` | string | No | Install command for grader dependencies |
 | `rubric` | string | LLM only | Evaluation rubric text or file path |
-| `model` | string | No | LLM model override |
+| `provider` | string | No | LLM provider: `gemini` (default), `anthropic`, or `openai` |
+| `model` | string | No | LLM model override (each provider has a default) |
 | `weight` | number | No | Grader weight (default: 1) |
 
 ## File References

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -122,6 +122,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
                 : resolved.graders,
             timeoutSec: resolved.timeout,
             graderModel: resolved.grader_model,
+            graderProvider: resolved.grader_provider,
             environment: resolved.environment,
         };
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -127,6 +127,7 @@ function validateConfig(raw: any): EvalConfig {
                 run: g.run,
                 rubric: g.rubric,
                 model: g.model,
+                provider: g.provider,
                 weight: g.weight ?? 1.0,
             })),
             solution: t.solution,
@@ -175,6 +176,7 @@ export async function resolveTask(
                 type: g.type,
                 setup: g.setup,
                 model: g.model,
+                provider: g.provider,
                 weight: g.weight,
             };
             if (g.type === 'deterministic' && g.run) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -95,6 +95,12 @@ function validateConfig(raw: any): EvalConfig {
         defaults.acp = acp;
     }
 
+    // Validate grader_provider
+    const validGraderProviders = ['gemini', 'anthropic', 'openai'];
+    if (defaults.grader_provider && !validGraderProviders.includes(defaults.grader_provider)) {
+        throw new Error(`eval.yaml: grader_provider must be one of ${validGraderProviders.join(', ')}, got "${defaults.grader_provider}"`);
+    }
+
     if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
         throw new Error('eval.yaml must have at least one task in the "tasks" array');
     }
@@ -104,6 +110,9 @@ function validateConfig(raw: any): EvalConfig {
         if (!t.instruction) throw new Error(`Task "${t.name}" is missing an "instruction"`);
         if (!t.graders || !Array.isArray(t.graders) || t.graders.length === 0) {
             throw new Error(`Task "${t.name}" must have at least one grader`);
+        }
+        if (t.grader_provider && !validGraderProviders.includes(t.grader_provider)) {
+            throw new Error(`Task "${t.name}" has invalid grader_provider "${t.grader_provider}", must be one of ${validGraderProviders.join(', ')}`);
         }
 
         const workspace: WorkspaceMapping[] = (t.workspace || []).map((w: any) => {
@@ -121,21 +130,29 @@ function validateConfig(raw: any): EvalConfig {
             name: t.name,
             instruction: t.instruction,
             workspace,
-            graders: t.graders.map((g: any) => ({
-                type: g.type,
-                setup: g.setup,
-                run: g.run,
-                rubric: g.rubric,
-                model: g.model,
-                provider: g.provider,
-                weight: g.weight ?? 1.0,
-            })),
+            graders: t.graders.map((g: any) => {
+                if (g.provider && !validGraderProviders.includes(g.provider)) {
+                    throw new Error(`Task "${t.name}" grader has invalid provider "${g.provider}", must be one of ${validGraderProviders.join(', ')}`);
+                }
+                return {
+                    type: g.type,
+                    setup: g.setup,
+                    run: g.run,
+                    rubric: g.rubric,
+                    model: g.model,
+                    provider: g.provider,
+                    weight: g.weight ?? 1.0,
+                };
+            }),
             solution: t.solution,
             agent: t.agent,
             provider: t.provider,
             trials: t.trials,
             timeout: t.timeout,
+            grader_model: t.grader_model,
+            grader_provider: t.grader_provider,
             docker: t.docker,
+            environment: t.environment,
         };
     });
 
@@ -164,6 +181,7 @@ export async function resolveTask(
         ...(task.environment || {}),
     };
     const grader_model = task.grader_model || defaults.grader_model;
+    const grader_provider = task.grader_provider || defaults.grader_provider;
     const acp = defaults.acp;  // ACP config is only at defaults level
 
     // Resolve instruction — could be inline text or file path
@@ -205,6 +223,7 @@ export async function resolveTask(
         trials,
         timeout,
         grader_model,
+        grader_provider,
         acp,
         docker,
         environment,

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -15,10 +15,11 @@ export interface WorkspaceMapping {
 /** Grader definition */
 export interface EvalGraderConfig {
     type: 'deterministic' | 'llm_rubric';
-    setup?: string;     // commands to install grader dependencies (runs during image build)
-    run?: string;       // inline script or file path (deterministic)
-    rubric?: string;    // inline rubric or file path (llm_rubric)
-    model?: string;     // LLM model override (e.g. 'gemini-2.0-flash', 'claude-sonnet-4-20250514')
+    setup?: string;                               // commands to install grader dependencies (runs during image build)
+    run?: string;                                 // inline script or file path (deterministic)
+    rubric?: string;                              // inline rubric or file path (llm_rubric)
+    model?: string;                               // model override, e.g. 'claude-sonnet-4-20250514' or 'gemini-3-flash-preview'
+    provider?: 'gemini' | 'anthropic' | 'openai'; // which LLM API to call (default: 'gemini')
     weight: number;
 }
 
@@ -100,9 +101,10 @@ export interface ResolvedTask {
 
 export interface ResolvedGrader {
     type: 'deterministic' | 'llm_rubric';
-    setup?: string;     // resolved setup commands
-    run?: string;       // resolved content for deterministic
-    rubric?: string;    // resolved content for llm_rubric
-    model?: string;     // LLM model override
+    setup?: string;                               // resolved setup commands
+    run?: string;                                 // resolved content for deterministic
+    rubric?: string;                              // resolved content for llm_rubric
+    model?: string;                               // resolved model override
+    provider?: 'gemini' | 'anthropic' | 'openai'; // which LLM API to call (default: 'gemini')
     weight: number;
 }

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -57,6 +57,7 @@ export interface EvalTaskConfig {
     trials?: number;
     timeout?: number;
     grader_model?: string;
+    grader_provider?: 'gemini' | 'anthropic' | 'openai';
     docker?: DockerConfig;
     environment?: Partial<EnvironmentConfig>;
 }
@@ -68,7 +69,8 @@ export interface EvalDefaults {
     trials: number;
     timeout: number;
     threshold: number;  // for --ci mode
-    grader_model?: string;  // default LLM grader model
+    grader_model?: string;      // default LLM grader model
+    grader_provider?: 'gemini' | 'anthropic' | 'openai';  // default LLM grader provider
     acp?: AcpConfig;    // ACP agent configuration
     docker: DockerConfig;
     environment: EnvironmentConfig;
@@ -93,7 +95,8 @@ export interface ResolvedTask {
     provider: string;
     trials: number;
     timeout: number;
-    grader_model?: string;  // inherited default model for LLM graders
+    grader_model?: string;                                      // inherited default model for LLM graders
+    grader_provider?: 'gemini' | 'anthropic' | 'openai';        // inherited default provider for LLM graders
     acp?: AcpConfig;        // ACP agent configuration
     docker: DockerConfig;
     environment: EnvironmentConfig;

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -65,6 +65,7 @@ export interface EvalRunOptions {
     graders: ResolvedGrader[];
     timeoutSec: number;
     graderModel?: string;       // default LLM grader model
+    graderProvider?: 'gemini' | 'anthropic' | 'openai';  // default LLM grader provider
     graderTimeoutSec?: number;  // timeout per grader (default: 120s)
     environment: {
         cpus: number;
@@ -244,7 +245,7 @@ export class EvalRunner {
                         ? `prompts/${llmIndex === 0 ? 'quality.md' : `quality_${llmIndex}.md`}`
                         : undefined,
                     model: graderDef.model || opts.graderModel,
-                    provider: graderDef.provider,
+                    provider: graderDef.provider || opts.graderProvider,
                     weight: graderDef.weight,
                 };
 

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -244,6 +244,7 @@ export class EvalRunner {
                         ? `prompts/${llmIndex === 0 ? 'quality.md' : `quality_${llmIndex}.md`}`
                         : undefined,
                     model: graderDef.model || opts.graderModel,
+                    provider: graderDef.provider,
                     weight: graderDef.weight,
                 };
 

--- a/src/graders/index.ts
+++ b/src/graders/index.ts
@@ -79,9 +79,24 @@ export class DeterministicGrader implements Grader {
 
 /**
  * Uses an LLM to evaluate the agent's session transcript against a rubric.
- * Requires GEMINI_API_KEY or ANTHROPIC_API_KEY in the environment.
+ *
+ * Supported providers (selected via `config.provider`, defaults to "gemini"):
+ *   - gemini      → Google Gemini (GEMINI_API_KEY)
+ *   - anthropic   → Anthropic Claude or compatible (ANTHROPIC_API_KEY; optional ANTHROPIC_BASE_URL)
+ *   - openai      → OpenAI or compatible (OPENAI_API_KEY; optional OPENAI_BASE_URL for Ollama, vLLM, etc.)
+ *
+ * Each provider method resolves its own API key, makes the HTTP call, and
+ * handles errors — returning a zero-score GraderResult on any failure.
  */
 export class LLMGrader implements Grader {
+
+    /** Default models when no model override is configured. */
+    private static readonly DEFAULT_MODELS: Record<string, string> = {
+        gemini: 'gemini-3-flash-preview',
+        anthropic: 'claude-sonnet-4-20250514',
+        openai: 'gpt-4o',
+    };
+
     async grade(
         _workspace: string,
         _provider: EnvironmentProvider,
@@ -151,26 +166,36 @@ ${transcript}
 
 Respond with ONLY a JSON object: {"score": <number>, "reasoning": "<brief explanation>"}`;
 
-        // Try Gemini API first, fall back to Anthropic
-        const apiKey = env?.GEMINI_API_KEY || process.env.GEMINI_API_KEY;
-        const anthropicKey = env?.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY;
+        const providerName = config.provider || 'gemini';
+        const model = config.model || LLMGrader.DEFAULT_MODELS[providerName] || 'gemini-3-flash-preview';
 
-        if (apiKey) {
-            return this.callGemini(prompt, apiKey, config);
-        } else if (anthropicKey) {
-            return this.callAnthropic(prompt, anthropicKey, config);
+        switch (providerName) {
+            case "gemini":
+                return this.callGemini(prompt, model, config, env);
+            case "anthropic":
+                return this.callAnthropic(prompt, model, config, env);
+            case "openai":
+                return this.callOpenAI(prompt, model, config, env);
+            default:
+                return {
+                    grader_type: 'llm_rubric',
+                    score: 0,
+                    weight: config.weight,
+                    details: `Unknown grader provider: "${providerName}". Supported: gemini, anthropic, openai`,
+                };
         }
-
-        return {
-            grader_type: 'llm_rubric',
-            score: 0,
-            weight: config.weight,
-            details: 'No API key available for LLM grading (set GEMINI_API_KEY or ANTHROPIC_API_KEY)'
-        };
     }
 
-    private async callGemini(prompt: string, apiKey: string, config: GraderConfig): Promise<GraderResult> {
-        const model = config.model || 'gemini-3-flash-preview';
+    private async callGemini(prompt: string, model: string, config: GraderConfig, env?: Record<string, string>): Promise<GraderResult> {
+        const apiKey = env?.GEMINI_API_KEY || process.env.GEMINI_API_KEY;
+        if (!apiKey) {
+            return {
+                grader_type: 'llm_rubric',
+                score: 0,
+                weight: config.weight,
+                details: 'Missing GEMINI_API_KEY. Set the GEMINI_API_KEY environment variable to use the "gemini" grader provider.'
+            };
+        }
         const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 
         try {
@@ -191,10 +216,21 @@ Respond with ONLY a JSON object: {"score": <number>, "reasoning": "<brief explan
         }
     }
 
-    private async callAnthropic(prompt: string, apiKey: string, config: GraderConfig): Promise<GraderResult> {
-        const model = config.model || 'claude-sonnet-4-20250514';
+    private async callAnthropic(prompt: string, model: string, config: GraderConfig, env?: Record<string, string>): Promise<GraderResult> {
+        const apiKey = env?.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY;
+        if (!apiKey) {
+            return {
+                grader_type: 'llm_rubric',
+                score: 0,
+                weight: config.weight,
+                details: 'Missing ANTHROPIC_API_KEY. Set the ANTHROPIC_API_KEY environment variable to use the "anthropic" grader provider.'
+            };
+        }
+        const baseUrl = (env?.ANTHROPIC_BASE_URL || process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com/v1').replace(/\/+$/, '');
+        const url = `${baseUrl}/messages`;
+
         try {
-            const response = await fetch('https://api.anthropic.com/v1/messages', {
+            const response = await fetch(url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -213,6 +249,42 @@ Respond with ONLY a JSON object: {"score": <number>, "reasoning": "<brief explan
             return this.parseResponse(text, config);
         } catch (e) {
             return { grader_type: 'llm_rubric', score: 0, weight: config.weight, details: `Anthropic API error: ${e}` };
+        }
+    }
+
+    private async callOpenAI(prompt: string, model: string, config: GraderConfig, env?: Record<string, string>): Promise<GraderResult> {
+        const apiKey = env?.OPENAI_API_KEY || process.env.OPENAI_API_KEY;
+        if (!apiKey) {
+            return {
+                grader_type: 'llm_rubric',
+                score: 0,
+                weight: config.weight,
+                details: 'Missing OPENAI_API_KEY. Set the OPENAI_API_KEY environment variable to use the "openai" grader provider.'
+            };
+        }
+        const baseUrl = (env?.OPENAI_BASE_URL || process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1').replace(/\/+$/, '');
+        const url = `${baseUrl}/chat/completions`;
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                    model,
+                    temperature: 0,
+                    max_tokens: 4096,
+                    messages: [{ role: 'user', content: prompt }],
+                }),
+            });
+
+            const data = await response.json() as any;
+            const text = data?.choices?.[0]?.message?.content || '';
+            return this.parseResponse(text, config);
+        } catch (e) {
+            return { grader_type: 'llm_rubric', score: 0, weight: config.weight, details: `OpenAI API error: ${e}` };
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,10 @@ export interface CommandResult {
 
 export interface GraderConfig {
     type: 'deterministic' | 'llm_rubric';
-    command?: string;         // for deterministic: shell command to execute (e.g. 'bash tests/test.sh')
-    rubric?: string;          // for llm_rubric: file path to rubric (e.g. 'prompts/quality.md')
-    model?: string;           // for llm_rubric: LLM model override
+    command?: string;                             // for deterministic: shell command to execute (e.g. 'bash tests/test.sh')
+    rubric?: string;                              // for llm_rubric: file path to rubric (e.g. 'prompts/quality.md')
+    model?: string;                               // for llm_rubric: LLM model override
+    provider?: 'gemini' | 'anthropic' | 'openai'; // for llm_rubric: which LLM API to call (default: 'gemini')
     weight: number;
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -207,6 +207,130 @@ tasks:
     const config = await loadEvalConfig('/test');
     expect(config.tasks[0].graders[0].weight).toBe(1.0);
   });
+
+  it('parses grader_provider from defaults', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  grader_provider: anthropic
+tasks:
+  - name: test-task
+    instruction: do it
+    graders:
+      - type: llm_rubric
+        rubric: "check quality"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.defaults.grader_provider).toBe('anthropic');
+  });
+
+  it('rejects invalid grader_provider value', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  grader_provider: invalid_provider
+tasks:
+  - name: test-task
+    instruction: do it
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    await expect(loadEvalConfig('/test')).rejects.toThrow('grader_provider must be one of');
+  });
+
+  it('rejects invalid provider on individual grader', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+tasks:
+  - name: test-task
+    instruction: do it
+    graders:
+      - type: llm_rubric
+        rubric: "check quality"
+        provider: invalid_provider
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    await expect(loadEvalConfig('/test')).rejects.toThrow('grader has invalid provider');
+  });
+
+  it('rejects invalid grader_provider at task level', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+tasks:
+  - name: test-task
+    instruction: do it
+    grader_provider: bad_provider
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    await expect(loadEvalConfig('/test')).rejects.toThrow('has invalid grader_provider');
+  });
+
+  it('preserves task-level grader_provider through loadEvalConfig', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  grader_provider: gemini
+tasks:
+  - name: test-task
+    instruction: do it
+    grader_provider: anthropic
+    graders:
+      - type: llm_rubric
+        rubric: "check quality"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.tasks[0].grader_provider).toBe('anthropic');
+  });
+
+  it('preserves task-level grader_model through loadEvalConfig', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  grader_model: gemini-1.5-flash
+tasks:
+  - name: test-task
+    instruction: do it
+    grader_model: claude-3-5-sonnet
+    graders:
+      - type: llm_rubric
+        rubric: "check quality"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.tasks[0].grader_model).toBe('claude-3-5-sonnet');
+  });
+
+  it('preserves task-level environment through loadEvalConfig', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+tasks:
+  - name: test-task
+    instruction: do it
+    environment:
+      cpus: 4
+      memory_mb: 4096
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.tasks[0].environment).toEqual({ cpus: 4, memory_mb: 4096 });
+  });
 });
 
 describe('resolveTask', () => {
@@ -236,6 +360,61 @@ describe('resolveTask', () => {
     expect(resolved.trials).toBe(5);
     expect(resolved.timeout).toBe(300);
     expect(resolved.docker.base).toBe('node:20-slim');
+  });
+
+  it('resolves grader_provider on the task level', async () => {
+    const defaultsWitProvider: EvalDefaults = {
+      ...defaults,
+      grader_provider: 'anthropic',
+    };
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      graders: [{ type: 'llm_rubric', rubric: 'check quality', weight: 1.0 }],
+    };
+
+    const resolved = await resolveTask(task, defaultsWitProvider, '/base');
+    expect(resolved.grader_provider).toBe('anthropic');
+    expect(resolved.graders[0].provider).toBeUndefined();
+  });
+
+  it('grader-level provider is preserved as-is', async () => {
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      graders: [{ type: 'llm_rubric', rubric: 'check quality', weight: 1.0, provider: 'openai' }],
+    };
+
+    const resolved = await resolveTask(task, defaults, '/base');
+    expect(resolved.graders[0].provider).toBe('openai');
+  });
+
+  it('grader without explicit provider remains undefined', async () => {
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      graders: [{ type: 'llm_rubric', rubric: 'check quality', weight: 1.0 }],
+    };
+
+    const resolved = await resolveTask(task, defaults, '/base');
+    expect(resolved.graders[0].provider).toBeUndefined();
+  });
+
+  it('task-level grader_provider overrides defaults', async () => {
+    const defaultsWitProvider: EvalDefaults = {
+      ...defaults,
+      grader_provider: 'gemini',
+    };
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      grader_provider: 'openai',
+      graders: [{ type: 'llm_rubric', rubric: 'check quality', weight: 1.0 }],
+    };
+
+    const resolved = await resolveTask(task, defaultsWitProvider, '/base');
+    expect(resolved.grader_provider).toBe('openai');
+    expect(resolved.graders[0].provider).toBeUndefined();
   });
 
   it('task overrides take precedence over defaults', async () => {

--- a/tests/graders.test.ts
+++ b/tests/graders.test.ts
@@ -332,7 +332,7 @@ describe('LLMGrader', () => {
       } as any);
 
       const provider = makeProvider('');
-      const env = { ANTHROPIC_API_KEY: 'test-key', ANTHROPIC_BASE_URL: 'http://localhost:8080' };
+      const env = { ANTHROPIC_API_KEY: 'test-key', ANTHROPIC_BASE_URL: 'http://localhost:8080/v1' };
       const config: GraderConfig = { ...baseConfig, provider: 'anthropic' };
       const result = await grader.grade('/workspace', provider, config, '/task', [], env);
 

--- a/tests/graders.test.ts
+++ b/tests/graders.test.ts
@@ -144,23 +144,38 @@ describe('LLMGrader', () => {
     expect(result.details).toContain('Rubric file not found');
   });
 
-  it('returns score 0 when no API key available', async () => {
+  it('returns score 0 when no API key for default provider (gemini)', async () => {
     mockPathExists.mockResolvedValue(true as any);
     mockReadFile.mockResolvedValue('Evaluate the code quality.' as any);
     const provider = makeProvider('');
 
     // Remove env vars
     const origGemini = process.env.GEMINI_API_KEY;
-    const origAnthropic = process.env.ANTHROPIC_API_KEY;
     delete process.env.GEMINI_API_KEY;
-    delete process.env.ANTHROPIC_API_KEY;
 
     try {
       const result = await grader.grade('/workspace', provider, baseConfig, '/task', []);
       expect(result.score).toBe(0);
-      expect(result.details).toContain('No API key');
+      expect(result.details).toContain('GEMINI_API_KEY');
     } finally {
       if (origGemini) process.env.GEMINI_API_KEY = origGemini;
+    }
+  });
+
+  it('returns score 0 when explicit provider has no API key', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    mockReadFile.mockResolvedValue('Evaluate the code quality.' as any);
+    const provider = makeProvider('');
+
+    const origAnthropic = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+
+    try {
+      const config: GraderConfig = { type: 'llm_rubric', rubric: 'rubric.md', weight: 1.0, provider: 'anthropic' };
+      const result = await grader.grade('/workspace', provider, config, '/task', []);
+      expect(result.score).toBe(0);
+      expect(result.details).toContain('ANTHROPIC_API_KEY');
+    } finally {
       if (origAnthropic) process.env.ANTHROPIC_API_KEY = origAnthropic;
     }
   });
@@ -174,10 +189,19 @@ describe('LLMGrader', () => {
     expect(result.details).toContain('prompts/quality.md');
   });
 
-  describe('parseResponse (via grade)', () => {
-    // Test parseResponse indirectly through callGemini
-    // We mock fetch to control API responses
+  it('returns score 0 for unknown provider name', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    mockReadFile.mockResolvedValue('rubric content' as any);
 
+    const provider = makeProvider('');
+    const config: GraderConfig = { type: 'llm_rubric', rubric: 'rubric.md', weight: 1.0, provider: 'unknown' as any };
+    const result = await grader.grade('/workspace', provider, config, '/task', []);
+
+    expect(result.score).toBe(0);
+    expect(result.details).toContain('Unknown grader provider');
+  });
+
+  describe('gemini provider', () => {
     it('parses valid JSON from LLM response', async () => {
       mockPathExists.mockResolvedValue(true as any);
       mockReadFile.mockResolvedValue('rubric content' as any);
@@ -264,54 +288,119 @@ describe('LLMGrader', () => {
 
       globalThis.fetch = originalFetch;
     });
+  });
 
-    it('falls back to Anthropic when Gemini key missing', async () => {
+  describe('anthropic provider', () => {
+    it('calls Anthropic API when provider is anthropic', async () => {
       mockPathExists.mockResolvedValue(true as any);
       mockReadFile.mockResolvedValue('rubric content' as any);
 
       const originalFetch = globalThis.fetch;
-      const origGemini = process.env.GEMINI_API_KEY;
-      delete process.env.GEMINI_API_KEY;
-
       globalThis.fetch = vi.fn().mockResolvedValue({
         json: () => Promise.resolve({
           content: [{ text: '{"score": 0.85, "reasoning": "good"}' }],
         }),
       } as any);
 
-      try {
-        const provider = makeProvider('');
-        const env = { ANTHROPIC_API_KEY: 'test-key' };
-        const result = await grader.grade('/workspace', provider, baseConfig, '/task', [], env);
+      const provider = makeProvider('');
+      const env = { ANTHROPIC_API_KEY: 'test-key' };
+      const config: GraderConfig = { ...baseConfig, provider: 'anthropic' };
+      const result = await grader.grade('/workspace', provider, config, '/task', [], env);
 
-        expect(result.score).toBe(0.85);
-      } finally {
-        globalThis.fetch = originalFetch;
-        if (origGemini) process.env.GEMINI_API_KEY = origGemini;
-      }
+      expect(result.score).toBe(0.85);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://api.anthropic.com/v1/messages',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'x-api-key': 'test-key' }),
+        })
+      );
+
+      globalThis.fetch = originalFetch;
     });
 
-    it('handles Anthropic fetch error', async () => {
+    it('respects ANTHROPIC_BASE_URL env var', async () => {
       mockPathExists.mockResolvedValue(true as any);
       mockReadFile.mockResolvedValue('rubric content' as any);
 
       const originalFetch = globalThis.fetch;
-      const origGemini = process.env.GEMINI_API_KEY;
-      delete process.env.GEMINI_API_KEY;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({
+          content: [{ text: '{"score": 0.9, "reasoning": "custom endpoint"}' }],
+        }),
+      } as any);
 
-      globalThis.fetch = vi.fn().mockRejectedValue(new Error('Anthropic down'));
+      const provider = makeProvider('');
+      const env = { ANTHROPIC_API_KEY: 'test-key', ANTHROPIC_BASE_URL: 'http://localhost:8080' };
+      const config: GraderConfig = { ...baseConfig, provider: 'anthropic' };
+      const result = await grader.grade('/workspace', provider, config, '/task', [], env);
 
-      try {
-        const provider = makeProvider('');
-        const env = { ANTHROPIC_API_KEY: 'test-key' };
-        const result = await grader.grade('/workspace', provider, baseConfig, '/task', [], env);
+      expect(result.score).toBe(0.9);
 
-        expect(result.score).toBe(0);
-        expect(result.details).toContain('Anthropic API error');
-      } finally {
-        globalThis.fetch = originalFetch;
-        if (origGemini) process.env.GEMINI_API_KEY = origGemini;
-      }
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'http://localhost:8080/v1/messages',
+        expect.anything()
+      );
+
+      globalThis.fetch = originalFetch;
+    });
+  });
+
+  describe('openai provider', () => {
+    it('calls OpenAI API when provider is openai', async () => {
+      mockPathExists.mockResolvedValue(true as any);
+      mockReadFile.mockResolvedValue('rubric content' as any);
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({
+          choices: [{ message: { content: '{"score": 0.75, "reasoning": "solid"}' } }],
+        }),
+      } as any);
+
+      const provider = makeProvider('');
+      const env = { OPENAI_API_KEY: 'test-key' };
+      const config: GraderConfig = { ...baseConfig, provider: 'openai' };
+      const result = await grader.grade('/workspace', provider, config, '/task', [], env);
+
+      expect(result.score).toBe(0.75);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'Authorization': 'Bearer test-key' }),
+        })
+      );
+
+      globalThis.fetch = originalFetch;
+    });
+
+    it('respects OPENAI_BASE_URL env var', async () => {
+      mockPathExists.mockResolvedValue(true as any);
+      mockReadFile.mockResolvedValue('rubric content' as any);
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({
+          choices: [{ message: { content: '{"score": 0.8, "reasoning": "nice"}' } }],
+        }),
+      } as any);
+
+      const provider = makeProvider('');
+      const env = { OPENAI_API_KEY: 'test-key', OPENAI_BASE_URL: 'http://localhost:11434/v1' };
+      const config: GraderConfig = { ...baseConfig, provider: 'openai' };
+      const result = await grader.grade('/workspace', provider, config, '/task', [], env);
+
+      expect(result.score).toBe(0.8);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'http://localhost:11434/v1/chat/completions',
+        expect.anything()
+      );
+
+      globalThis.fetch = originalFetch;
     });
   });
 


### PR DESCRIPTION
Hi @mgechev. This PR adds a provider field for the grader configuration and support for setting the base url for the providers.

I wanted to use local models for the llm grading. Since many tools support both anthropic and openai compatible APIs I added support for the latter in adition to being able to set the base url using environment variable.

Would you be interested in this feature?
