### PR TITLE
fix: handle empty content in OpenAI-compatible API responses

### DIFF
--- a/src/graders/index.ts
+++ b/src/graders/index.ts
@@ -281,8 +281,13 @@ Respond with ONLY a JSON object: {"score": <number>, "reasoning": "<brief explan
             });
 
             const data = await response.json() as any;
-            const text = data?.choices?.[0]?.message?.content || '';
-            return this.parseResponse(text, config);
+            const msg = data?.choices?.[0]?.message;
+            const text = msg?.content || msg?.reasoning_content || '';
+            const result = this.parseResponse(text, config);
+            if (result.score === 0 && result.details.startsWith('Failed to parse')) {
+                result.details = `Failed to parse LLM response: ${JSON.stringify(data).substring(0, 500)}`;
+            }
+            return result;
         } catch (e) {
             return { grader_type: 'llm_rubric', score: 0, weight: config.weight, details: `OpenAI API error: ${e}` };
         }

--- a/tests/graders.test.ts
+++ b/tests/graders.test.ts
@@ -486,9 +486,55 @@ describe('LLMGrader', () => {
     expect(prompt).toContain('Done!');
     expect(prompt).toContain('deterministic');
 
-    globalThis.fetch = originalFetch;
+      globalThis.fetch = originalFetch;
+    });
+
+    it('falls back to reasoning_content when content is empty', async () => {
+      mockPathExists.mockResolvedValue(true as any);
+      mockReadFile.mockResolvedValue('rubric content' as any);
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({
+          choices: [{ message: { content: '', reasoning_content: '{"score": 0.6, "reasoning": "via reasoning"}' } }],
+        }),
+      } as any);
+
+      const provider = makeProvider('');
+      const env = { OPENAI_API_KEY: 'test-key' };
+      const config: GraderConfig = { ...baseConfig, provider: 'openai' };
+      const result = await grader.grade('/workspace', provider, config, '/task', [], env);
+
+      expect(result.score).toBe(0.6);
+      expect(result.details).toBe('via reasoning');
+
+      globalThis.fetch = originalFetch;
+    });
+
+    it('includes raw response data in error when parsing fails', async () => {
+      mockPathExists.mockResolvedValue(true as any);
+      mockReadFile.mockResolvedValue('rubric content' as any);
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({
+          choices: [{ message: {} }],
+          model: 'deepseek-reasoning',
+        }),
+      } as any);
+
+      const provider = makeProvider('');
+      const env = { OPENAI_API_KEY: 'test-key', OPENAI_BASE_URL: 'http://localhost:11434/v1' };
+      const config: GraderConfig = { ...baseConfig, provider: 'openai' };
+      const result = await grader.grade('/workspace', provider, config, '/task', [], env);
+
+      expect(result.score).toBe(0);
+      expect(result.details).toContain('Failed to parse LLM response');
+      expect(result.details).toContain('deepseek-reasoning');
+
+      globalThis.fetch = originalFetch;
+    });
   });
-});
 
 describe('getGrader', () => {
   it('returns DeterministicGrader for "deterministic"', () => {


### PR DESCRIPTION
When an OpenAI-compatible API (like DeepSeek reasoning models or OpenCode Go API) returns an empty `content` field, the grader silently fails with `"Failed to parse LLM response: "` with no useful error details.

1. **Fall back to `reasoning_content`**: When `message.content` is empty/`null`, the grader now tries `message.reasoning_content`. This handles DeepSeek reasoning models that put their output in `reasoning_content` instead of `content` at low `max_tokens`.

2. **Include raw response in error**: When parsing still fails, the error message now includes the raw API response body (trunc to 500 chars) so users can debug what the API actually returned.

Fixes #21