### PR TITLE
feat: add interactive (multi-turn) evaluation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The easiest way to evaluate your [Agent Skills](https://agentskills.io/home). Tests that AI agents correctly discover and use your skills.
 
-See [examples/](examples/) — [superlint](examples/superlint/) (simple) and [angular-modern](examples/angular-modern/) (TypeScript grader).
+See [examples/](examples/) — [superlint](examples/superlint/) (simple), [angular-modern](examples/angular-modern/) (TypeScript grader), and [interactive-demo](examples/interactive-demo/) (multi-turn).
 
 ![Browser Preview](https://raw.githubusercontent.com/mgechev/skillgrade/main/assets/browser-preview.png)
 
@@ -59,7 +59,7 @@ Reports are saved to `$TMPDIR/skillgrade/<skill-name>/results/`. Override with `
 | `--grader=TYPE` | Run only graders of a type (`deterministic` or `llm_rubric`) |
 | `--trials=N` | Override trial count |
 | `--parallel=N` | Run trials concurrently |
-| `--agent=gemini\|claude\|codex\|acp\|opencode` | Override agent (default: auto-detect from API key) |
+| `--agent=gemini\|claude\|claude-stream\|codex\|acp\|opencode` | Override agent (default: auto-detect from API key) |
 | `--provider=docker\|local` | Override provider |
 | `--acp-command=CMD` | ACP agent command (e.g., `gemini --acp`) |
 | `--opencode-agent=NAME` | OpenCode agent (build\|plan\|explore) |
@@ -79,7 +79,7 @@ version: "1"
 # skill: path/to/my-skill
 
 defaults:
-  agent: gemini          # gemini | claude | codex | acp | opencode
+  agent: gemini          # gemini | claude | claude-stream | codex | acp | opencode
   provider: docker       # docker | local
   trials: 5
   timeout: 300           # seconds
@@ -127,6 +127,27 @@ tasks:
     grader_provider: anthropic   # override default LLM grader provider
     trials: 10
     timeout: 600
+
+    # Multi-turn interactive evaluation (optional)
+    interactive:
+      enabled: true
+      max_turns: 5
+      timeout_per_turn: 60
+      input_requests:
+        patterns:
+          - pattern: "\\[NEEDS_INPUT:confirmation\\]"
+            type: confirmation
+            response: "YES"
+      injections:
+        - trigger:
+            type: on_turn
+            turns: [2]
+          injector:
+            type: static
+            content: "Please verify edge cases too."
+      stop_conditions:
+        - type: output_matches
+          pattern: "[TASK COMPLETED]"
 ```
 
 String values (`instruction`, `rubric`, `run`) support **file references** — if the value is a valid file path, its contents are read automatically:
@@ -346,6 +367,102 @@ Any agent that supports the ACP protocol can be used:
 | `--acp-command=CMD` | Command to start the ACP agent |
 
 The `--acp-command` can also be set in `eval.yaml` under `defaults.acp.command`.
+
+## Interactive Evaluation (Multi-Turn)
+
+For skills that require back-and-forth conversation, interactive evaluation runs a multi-turn session where the agent exchanges messages with simulated user inputs.
+
+See the [interactive-demo](examples/interactive-demo/) example.
+
+### Quick Start
+
+Add `interactive` to a task in `eval.yaml`:
+
+```yaml
+tasks:
+  - name: interactive-code-fix
+    instruction: |
+      Fix the bugs in app.js. After each fix, wait for confirmation.
+      When done, output: [TASK COMPLETED]
+    interactive:
+      enabled: true
+      max_turns: 5
+      timeout_per_turn: 60
+```
+
+When `interactive.enabled` is true and the agent is `claude`, skillgrade automatically uses the `claude-stream` agent which maintains a persistent process for true multi-turn conversation. Other agents fall back to prompt-based context passing.
+
+### Configuration Reference
+
+```yaml
+interactive:
+  enabled: true              # enable multi-turn mode
+  max_turns: 10              # maximum conversation turns (default: 10)
+  timeout_per_turn: 60       # per-turn timeout in seconds (optional)
+
+  # Context passing (for non-streaming agents)
+  context:
+    max_history_turns: 10    # history turns to include (default: 10)
+    include_system_prompt: false
+    system_prompt: "Optional system prompt"
+
+  # Auto-respond when agent requests input
+  input_requests:
+    patterns:
+      - pattern: "\\[NEEDS_INPUT:confirmation\\]"
+        type: confirmation
+        response: "YES"
+      - pattern: "\\[NEEDS_INPUT:choice\\]"
+        type: choice
+        response: "A"
+
+  # Inject input at specific points
+  injections:
+    - trigger:
+        type: on_turn        # on_turn | on_output_contains | on_needs_input | on_command
+        turns: [2, 4]
+      injector:
+        type: static         # static | file
+        content: "Feedback text"
+    - trigger:
+        type: on_output_contains
+        pattern: "TEST FAILED"
+      injector:
+        type: file
+        file: fixtures/feedback-{turn}.txt  # {turn} is replaced with turn number
+
+  # Stop conditions
+  stop_conditions:
+    - type: output_matches
+      pattern: "[TASK COMPLETED]"
+    - type: turns_reached
+      turns: 5
+    - type: command_executed
+      command: "exit"
+```
+
+### Trigger Types
+
+| Type | Description | Parameters |
+|------|-------------|------------|
+| `on_turn` | Fire at specific turn numbers | `turns: [2, 4]` |
+| `on_output_contains` | Fire when agent output matches | `pattern: "string"` |
+| `on_needs_input` | Fire when agent requests input | `input_type: "confirmation"` (optional) |
+| `on_command` | Fire when a command is executed | `command_pattern: "string"` |
+
+### Agent Output Markers
+
+Agents can signal input requests using markers in their output:
+
+| Marker | Type |
+|--------|------|
+| `[NEEDS_INPUT:confirmation]` | Request yes/no confirmation |
+| `[NEEDS_INPUT:choice]` | Request a choice selection |
+| `[NEEDS_INPUT:generic]` | Request any text input |
+| `[WAITING_FOR_USER]` | Generic wait for input |
+| `[AWAITING_CONFIRMATION]` | Wait for confirmation |
+
+Chinese markers are also supported: `等待用户确认:`, `等待用户输入:`, `请确认是否`, `请选择`.
 
 ## Best Practices
 

--- a/examples/interactive-demo/SKILL.md
+++ b/examples/interactive-demo/SKILL.md
@@ -1,0 +1,10 @@
+# Interactive Code Fix Skill
+
+A demo skill for multi-turn interactive evaluation. The agent fixes bugs in code and confirms changes with the user during the process.
+
+## Workflow
+
+1. Analyze code problems
+2. Propose a fix and wait for user confirmation
+3. Apply the fix
+4. Run tests to verify

--- a/examples/interactive-demo/app.js
+++ b/examples/interactive-demo/app.js
@@ -1,0 +1,39 @@
+// Calculator module with bugs
+
+function add(a, b) {
+  return a - b;  // Bug: should be a + b
+}
+
+function subtract(a, b) {
+  return a - b;
+}
+
+function multiply(a, b) {
+  return a * b;
+}
+
+function divide(a, b) {
+  return a / b;  // Bug: no check for division by zero
+}
+
+function calculate(expression) {
+  const parts = expression.split(' ');
+  const a = parseFloat(parts[0]);
+  const operator = parts[1];
+  const b = parseFloat(parts[2]);
+
+  switch (operator) {
+    case '+':
+      return add(a, b);
+    case '-':
+      return subtract(a, b);
+    case '*':
+      return multiply(a, b);
+    case '/':
+      return divide(a, b);
+    default:
+      return NaN;
+  }
+}
+
+module.exports = { add, subtract, multiply, divide, calculate };

--- a/examples/interactive-demo/eval.yaml
+++ b/examples/interactive-demo/eval.yaml
@@ -1,0 +1,69 @@
+# Multi-turn interactive evaluation demo
+
+version: "1"
+
+defaults:
+  agent: claude
+  provider: local
+  trials: 1
+  timeout: 300
+
+tasks:
+  - name: interactive-code-fix
+    instruction: |
+      Fix the bugs in app.js. The file has several bugs:
+      1. The add function returns wrong result
+      2. The divide function doesn't handle division by zero
+
+      After each fix, run the tests using: node fixtures/app.test.js
+      Wait for user confirmation before making irreversible changes.
+      When all tests pass, mark the task as complete with: [TASK COMPLETED]
+
+    workspace:
+      - src: app.js
+        dest: app.js
+      - src: fixtures/app.test.js
+        dest: fixtures/app.test.js
+
+    interactive:
+      enabled: true
+      max_turns: 5
+      timeout_per_turn: 60
+
+      input_requests:
+        patterns:
+          - pattern: "\\[NEEDS_INPUT:confirmation\\]"
+            type: confirmation
+            response: "YES, proceed with the fix"
+          - pattern: "\\[NEEDS_INPUT:choice\\]"
+            type: choice
+            response: "A"
+
+      injections:
+        - trigger:
+            type: on_turn
+            turns: [2]
+          injector:
+            type: static
+            content: "Please also verify that all edge cases are handled properly."
+        - trigger:
+            type: on_output_contains
+            pattern: "TEST FAILED"
+          injector:
+            type: static
+            content: "Tests are still failing. Please analyze the error messages and fix the issues."
+
+      stop_conditions:
+        - type: output_matches
+          pattern: "[TASK COMPLETED]"
+        - type: turns_reached
+          turns: 5
+
+    graders:
+      - type: deterministic
+        run: node fixtures/app.test.js 2>&1 | tail -1 | grep -q "4/4 tests passed" && echo '{"score":1.0,"details":"All tests passed"}' || echo '{"score":0.0,"details":"Tests failed"}'
+        weight: 0.7
+
+      - type: llm_rubric
+        rubric: prompts/multi-turn-quality.md
+        weight: 0.3

--- a/examples/interactive-demo/fixtures/app.test.js
+++ b/examples/interactive-demo/fixtures/app.test.js
@@ -1,0 +1,61 @@
+// Test file for app.js
+
+const { add, subtract, multiply, divide, calculate } = require('../app.js');
+
+function testAdd() {
+  const result = add(2, 3);
+  if (result !== 5) {
+    console.log(`TEST FAILED: add(2, 3) = ${result}, expected 5`);
+    return false;
+  }
+  console.log('TEST PASSED: add');
+  return true;
+}
+
+function testSubtract() {
+  const result = subtract(5, 3);
+  if (result !== 2) {
+    console.log(`TEST FAILED: subtract(5, 3) = ${result}, expected 2`);
+    return false;
+  }
+  console.log('TEST PASSED: subtract');
+  return true;
+}
+
+function testDivide() {
+  if (divide(6, 2) !== 3) {
+    console.log('TEST FAILED: divide(6, 2)');
+    return false;
+  }
+
+  const result = divide(5, 0);
+  if (result !== null && result !== undefined && !Number.isNaN(result)) {
+    console.log('TEST FAILED: divide(5, 0) should handle division by zero');
+    return false;
+  }
+
+  console.log('TEST PASSED: divide');
+  return true;
+}
+
+function testCalculate() {
+  const result = calculate('2 + 3');
+  if (result !== 5) {
+    console.log(`TEST FAILED: calculate("2 + 3") = ${result}, expected 5`);
+    return false;
+  }
+  console.log('TEST PASSED: calculate');
+  return true;
+}
+
+const results = [testAdd(), testSubtract(), testDivide(), testCalculate()];
+const passed = results.filter(r => r).length;
+const total = results.length;
+
+console.log(`\nResults: ${passed}/${total} tests passed`);
+
+if (passed < total) {
+  process.exit(1);
+}
+
+process.exit(0);

--- a/examples/interactive-demo/prompts/multi-turn-quality.md
+++ b/examples/interactive-demo/prompts/multi-turn-quality.md
@@ -1,0 +1,27 @@
+# Multi-Turn Interaction Quality Rubric
+
+Evaluate the agent's performance in this multi-turn interactive session.
+
+## Scoring Criteria
+
+### Handling of User Requests (0.3 weight)
+- **1.0**: Agent correctly understood and responded to all user inputs and confirmations
+- **0.7**: Agent mostly understood user inputs with minor misunderstandings
+- **0.4**: Agent had difficulty understanding several user inputs
+- **0.0**: Agent failed to understand or respond to user inputs
+
+### Adaptation to Feedback (0.3 weight)
+- **1.0**: Agent effectively adapted its approach based on injected feedback
+- **0.7**: Agent acknowledged feedback but adaptation was incomplete
+- **0.4**: Agent ignored or misinterpreted feedback
+- **0.0**: Agent showed no adaptation to feedback
+
+### Problem Resolution (0.4 weight)
+- **1.0**: Problem was fully resolved with all tests passing
+- **0.7**: Problem mostly resolved with minor issues remaining
+- **0.4**: Problem partially resolved but major issues remain
+- **0.0**: Problem not resolved or made worse
+
+## Final Score
+
+Calculate the weighted average of the three criteria above.

--- a/src/agents/claude-stream.ts
+++ b/src/agents/claude-stream.ts
@@ -1,0 +1,224 @@
+import { ChildProcess, spawn } from 'child_process';
+import * as readline from 'readline';
+import { BaseAgent, CommandResult, AgentResult, SkillTriggerInfo } from '../types';
+
+const SKILL_PATH_REGEX = /(?:\.claude\/skills|\.agents\/skills|\.codefuse\/fuse\/skills)\/([^/]+)/;
+
+interface StreamEvent {
+    type: string;
+    [key: string]: any;
+}
+
+export class ClaudeStreamAgent extends BaseAgent {
+    protected binary = 'claude';
+
+    protected buildArgs(): string[] {
+        return [
+            '-p',
+            '--input-format', 'stream-json',
+            '--output-format', 'stream-json',
+            '--dangerously-skip-permissions',
+            '--verbose',
+        ];
+    }
+
+    private process: ChildProcess | null = null;
+    private rl: readline.Interface | null = null;
+    private lineBuffer: string[] = [];
+    private lineResolve: ((line: string) => void) | null = null;
+    private lineReject: ((err: Error) => void) | null = null;
+    private closed = false;
+
+    private _partialSkills: SkillTriggerInfo[] = [];
+    private _partialTools = new Set<string>();
+    private _partialSeenSkills = new Set<string>();
+    private _partialOutput = '';
+    private _partialNumTurns?: number;
+    private _partialDurationApiMs?: number;
+    private _partialCostUsd?: number;
+
+    start(workspacePath: string): void {
+        this.closed = false;
+        this.lineBuffer = [];
+        this.lineResolve = null;
+        this.lineReject = null;
+
+        this.process = spawn(this.binary, this.buildArgs(), {
+            cwd: workspacePath,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            env: { ...process.env },
+        });
+
+        this.rl = readline.createInterface({ input: this.process.stdout! });
+
+        this.rl.on('line', (line: string) => {
+            if (this.lineResolve) {
+                const resolve = this.lineResolve;
+                this.lineResolve = null;
+                this.lineReject = null;
+                resolve(line);
+            } else {
+                this.lineBuffer.push(line);
+            }
+        });
+
+        this.process.on('exit', () => {
+            this.closed = true;
+        });
+    }
+
+    private nextLine(): Promise<string> {
+        if (this.lineBuffer.length > 0) {
+            return Promise.resolve(this.lineBuffer.shift()!);
+        }
+        if (this.closed) {
+            return Promise.reject(new Error('Claude process exited unexpectedly'));
+        }
+        return new Promise<string>((resolve, reject) => {
+            this.lineResolve = resolve;
+            this.lineReject = reject;
+        });
+    }
+
+    async sendMessage(message: string): Promise<AgentResult> {
+        if (!this.process || this.closed) {
+            throw new Error('Claude stream process is not running');
+        }
+
+        this._partialSkills = [];
+        this._partialTools = new Set();
+        this._partialSeenSkills = new Set();
+        this._partialOutput = '';
+        this._partialNumTurns = undefined;
+        this._partialDurationApiMs = undefined;
+        this._partialCostUsd = undefined;
+
+        const userMsg = {
+            type: 'user',
+            message: { role: 'user', content: message },
+            parent_tool_use_id: null,
+        };
+        this.process.stdin!.write(JSON.stringify(userMsg) + '\n');
+
+        try {
+            while (true) {
+                const line = await this.nextLine();
+                let event: StreamEvent;
+                try {
+                    event = JSON.parse(line);
+                } catch {
+                    continue;
+                }
+
+                if (event.type === 'assistant' && event.message?.content) {
+                    for (const block of event.message.content) {
+                        if (block.type !== 'tool_use') continue;
+                        const toolName = block.name;
+                        this._partialTools.add(toolName);
+
+                        if (toolName === 'Skill' && block.input?.name) {
+                            const key = `tool:${block.input.name}`;
+                            if (!this._partialSeenSkills.has(key)) {
+                                this._partialSeenSkills.add(key);
+                                this._partialSkills.push({
+                                    name: block.input.name,
+                                    source: 'tool_use',
+                                    timestamp: new Date().toISOString(),
+                                    details: `Skill tool invoked with name="${block.input.name}"`,
+                                });
+                            }
+                        }
+
+                        if (toolName === 'Read' && block.input?.file_path) {
+                            const m = block.input.file_path.match(SKILL_PATH_REGEX);
+                            if (m && !this._partialSeenSkills.has(`read:${m[1]}`)) {
+                                this._partialSeenSkills.add(`read:${m[1]}`);
+                                this._partialSkills.push({
+                                    name: m[1],
+                                    source: 'file_read',
+                                    timestamp: new Date().toISOString(),
+                                    details: `Read file: ${block.input.file_path}`,
+                                });
+                            }
+                        }
+
+                        if (toolName === 'SlashCommand' && block.input?.command) {
+                            const sm = block.input.command.match(/^\/?([a-zA-Z0-9_-]+)/);
+                            if (sm && !this._partialSeenSkills.has(`slash:${sm[1]}`)) {
+                                this._partialSeenSkills.add(`slash:${sm[1]}`);
+                                this._partialSkills.push({
+                                    name: sm[1],
+                                    source: 'tool_use',
+                                    timestamp: new Date().toISOString(),
+                                    details: `SlashCommand: ${block.input.command}`,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                if (event.type === 'result') {
+                    this._partialOutput = event.result || '';
+                    this._partialNumTurns = event.num_turns;
+                    this._partialDurationApiMs = event.duration_api_ms;
+                    this._partialCostUsd = event.total_cost_usd;
+                    break;
+                }
+            }
+        } catch (err: any) {
+            if (err.message === 'Agent process closed' ||
+                err.message === 'Claude process exited unexpectedly') {
+                return this.getPartialResult();
+            }
+            throw err;
+        }
+
+        return this.getPartialResult();
+    }
+
+    getPartialResult(): AgentResult {
+        return {
+            output: this._partialOutput || '',
+            skills_triggered: [...this._partialSkills],
+            tools_used: Array.from(this._partialTools),
+            num_turns: this._partialNumTurns,
+            duration_api_ms: this._partialDurationApiMs,
+            cost_usd: this._partialCostUsd,
+        };
+    }
+
+    close(): void {
+        if (this.process && !this.closed) {
+            this.process.kill('SIGTERM');
+            this.closed = true;
+        }
+        if (this.lineReject) {
+            const reject = this.lineReject;
+            this.lineResolve = null;
+            this.lineReject = null;
+            reject(new Error('Agent process closed'));
+        }
+        if (this.rl) {
+            this.rl.close();
+            this.rl = null;
+        }
+        this.process = null;
+    }
+
+    isRunning(): boolean {
+        return !!this.process && !this.closed;
+    }
+
+    async run(
+        instruction: string,
+        workspacePath: string,
+        _runCommand: (cmd: string, env?: Record<string, string>) => Promise<CommandResult>
+    ): Promise<AgentResult> {
+        this.start(workspacePath);
+        try {
+            return await this.sendMessage(instruction);
+        } finally {
+            this.close();
+        }
+    }
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -11,6 +11,7 @@
 import { BaseAgent } from '../types';
 import { GeminiAgent } from './gemini';
 import { ClaudeAgent } from './claude';
+import { ClaudeStreamAgent } from './claude-stream';
 import { CodexAgent } from './codex';
 import { AcpAgent, AcpAgentConfig } from './acp';
 import { OpenCodeAgent, OpenCodeAgentConfig } from './opencode';
@@ -27,6 +28,7 @@ export interface AgentConfig {
 const AGENT_REGISTRY: Record<string, (config?: AgentConfig) => BaseAgent> = {
     gemini: () => new GeminiAgent(),
     claude: () => new ClaudeAgent(),
+    'claude-stream': () => new ClaudeStreamAgent(),
     codex: () => new CodexAgent(),
     // ACP agent requires config, registered as placeholder
     acp: (config) => new AcpAgent(config?.acp || { command: 'gemini --acp' }),

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -124,6 +124,8 @@ export async function runEvals(dir: string, opts: RunOptions) {
             graderModel: resolved.grader_model,
             graderProvider: resolved.grader_provider,
             environment: resolved.environment,
+            interactive: resolved.interactive,
+            taskPath: dir,
         };
 
         // Pick agent: CLI flag > task-level override > auto-detect from API key > default
@@ -141,6 +143,11 @@ export async function runEvals(dir: string, opts: RunOptions) {
             }
         }
         const providerName = opts.provider || resolved.provider;
+
+        // Auto-switch to claude-stream for interactive eval
+        if (resolved.interactive?.enabled && agentName === 'claude') {
+            agentName = 'claude-stream';
+        }
 
         // Build agent config
         const agentConfig: AgentConfig = {};

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -12,6 +12,7 @@ import {
     WorkspaceMapping,
     EnvironmentConfig,
     AcpConfig,
+    InteractiveConfig,
 } from './config.types';
 
 // We use a simple YAML parser — js-yaml is the standard
@@ -153,6 +154,7 @@ function validateConfig(raw: any): EvalConfig {
             grader_provider: t.grader_provider,
             docker: t.docker,
             environment: t.environment,
+            interactive: t.interactive ? validateInteractiveConfig(t.interactive) : undefined,
         };
     });
 
@@ -227,6 +229,80 @@ export async function resolveTask(
         acp,
         docker,
         environment,
+        interactive: task.interactive,
+    };
+}
+
+/**
+ * Validate and normalize interactive config.
+ */
+function validateInteractiveConfig(raw: any): InteractiveConfig {
+    if (!raw || typeof raw !== 'object') {
+        return { enabled: false, max_turns: 10 };
+    }
+
+    const enabled = raw.enabled === true;
+    const max_turns = typeof raw.max_turns === 'number' ? raw.max_turns : 10;
+    const timeout_per_turn = typeof raw.timeout_per_turn === 'number' ? raw.timeout_per_turn : undefined;
+
+    let input_requests: InteractiveConfig['input_requests'] | undefined;
+    if (raw.input_requests?.patterns && Array.isArray(raw.input_requests.patterns)) {
+        input_requests = {
+            patterns: raw.input_requests.patterns.map((p: any) => ({
+                pattern: String(p.pattern || ''),
+                type: String(p.type || 'generic'),
+                response: String(p.response || ''),
+            })),
+        };
+    }
+
+    let injections: InteractiveConfig['injections'] | undefined;
+    if (raw.injections && Array.isArray(raw.injections)) {
+        injections = raw.injections.map((inj: any) => ({
+            trigger: {
+                type: inj.trigger?.type || 'on_turn',
+                turns: inj.trigger?.turns,
+                pattern: inj.trigger?.pattern,
+                command_pattern: inj.trigger?.command_pattern,
+                input_type: inj.trigger?.input_type,
+            },
+            injector: {
+                type: inj.injector?.type || 'static',
+                content: inj.injector?.content,
+                file: inj.injector?.file,
+                script: inj.injector?.script,
+            },
+        }));
+    }
+
+    let stop_conditions: InteractiveConfig['stop_conditions'] | undefined;
+    if (raw.stop_conditions && Array.isArray(raw.stop_conditions)) {
+        stop_conditions = raw.stop_conditions.map((c: any) => ({
+            type: c.type || 'turns_reached',
+            pattern: c.pattern,
+            command: c.command,
+            turns: c.turns,
+        }));
+    }
+
+    // Validate context config
+    let context: InteractiveConfig['context'] | undefined;
+    if (raw.context && typeof raw.context === 'object') {
+        context = {
+            max_history_turns: typeof raw.context.max_history_turns === 'number' ? raw.context.max_history_turns : undefined,
+            include_system_prompt: raw.context.include_system_prompt === true ? true : undefined,
+            system_prompt: typeof raw.context.system_prompt === 'string' ? raw.context.system_prompt : undefined,
+        };
+    }
+
+    return {
+        enabled,
+        max_turns,
+        timeout_per_turn,
+        context,
+        input_requests,
+        injections,
+        stop_conditions,
     };
 }
 

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -60,6 +60,7 @@ export interface EvalTaskConfig {
     grader_provider?: 'gemini' | 'anthropic' | 'openai';
     docker?: DockerConfig;
     environment?: Partial<EnvironmentConfig>;
+    interactive?: InteractiveConfig;
 }
 
 /** Top-level defaults */
@@ -100,6 +101,7 @@ export interface ResolvedTask {
     acp?: AcpConfig;        // ACP agent configuration
     docker: DockerConfig;
     environment: EnvironmentConfig;
+    interactive?: InteractiveConfig;
 }
 
 export interface ResolvedGrader {
@@ -110,4 +112,66 @@ export interface ResolvedGrader {
     model?: string;                               // resolved model override
     provider?: 'gemini' | 'anthropic' | 'openai'; // which LLM API to call (default: 'gemini')
     weight: number;
+}
+
+// ==================== Interactive (multi-turn) config ====================
+
+/** Interaction trigger */
+export interface InteractionTrigger {
+    type: 'on_turn' | 'on_output_contains' | 'on_needs_input' | 'on_command';
+    turns?: number[];                 // on_turn: trigger on these turns [1, 3, 5]
+    pattern?: string;                 // on_output_contains: match pattern
+    command_pattern?: string;         // on_command: command match pattern
+    input_type?: string;              // on_needs_input: input request type
+}
+
+/** Input injector */
+export interface InputInjector {
+    type: 'static' | 'file' | 'dynamic';
+    content?: string;                 // static: inline content
+    file?: string;                    // file: file path (supports {turn} placeholder)
+    script?: string;                  // dynamic: script for generating content
+}
+
+/** Input request auto-response config */
+export interface InputRequestPattern {
+    pattern: string;                  // marker pattern in output (regex)
+    type: string;                     // request type
+    response: string;                 // auto-response content
+}
+
+/** Context passing config */
+export interface ContextConfig {
+    max_history_turns?: number;       // max history turns to avoid token overflow (default: 10)
+    include_system_prompt?: boolean;  // whether to include system prompt (default: false)
+    system_prompt?: string;           // custom system prompt
+}
+
+/** Interactive evaluation config */
+export interface InteractiveConfig {
+    enabled: boolean;                 // enable multi-turn mode
+    max_turns: number;                // max turns (default: 10)
+    timeout_per_turn?: number;        // per-turn timeout (seconds)
+
+    // Context passing config
+    context?: ContextConfig;
+
+    // Auto-responses when agent requests input
+    input_requests?: {
+        patterns: InputRequestPattern[];
+    };
+
+    // Predetermined injections
+    injections?: Array<{
+        trigger: InteractionTrigger;
+        injector: InputInjector;
+    }>;
+
+    // Stop conditions
+    stop_conditions?: Array<{
+        type: 'output_matches' | 'command_executed' | 'turns_reached';
+        pattern?: string;
+        command?: string;
+        turns?: number;
+    }>;
 }

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -4,22 +4,12 @@ import {
     BaseAgent, EnvironmentProvider,
     LogEntry, TrialResult, EvalReport, GraderResult, AgentResult
 } from './types';
-import { ResolvedGrader } from './core/config.types';
+import { ResolvedGrader, InteractiveConfig } from './core/config.types';
 import { getGrader } from './graders';
 import { fmt, Spinner } from './utils/cli';
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-        const timer = setTimeout(() => {
-            reject(new Error(`${label} timed out after ${timeoutMs / 1000}s`));
-        }, timeoutMs);
-
-        promise.then(
-            (val) => { clearTimeout(timer); resolve(val); },
-            (err) => { clearTimeout(timer); reject(err); }
-        );
-    });
-}
+import { withTimeout } from './utils/timeout';
+import { InteractiveSession, InputInjectorManager } from './interactive';
+import { ClaudeStreamAgent } from './agents/claude-stream';
 
 /**
  * Calculate pass@k: probability of at least 1 success in k trials
@@ -71,6 +61,8 @@ export interface EvalRunOptions {
         cpus: number;
         memory_mb: number;
     };
+    interactive?: InteractiveConfig;
+    taskPath?: string;
 }
 
 export class EvalRunner {
@@ -179,6 +171,10 @@ export class EvalRunner {
         total: number,
         env?: Record<string, string>
     ): Promise<TrialResult> {
+        if (opts.interactive?.enabled) {
+            return this.runInteractiveTrial(agent, taskPath, skillsPaths, opts, index, total, env);
+        }
+
         const sessionLog: LogEntry[] = [];
         let commandCount = 0;
         const startTime = Date.now();
@@ -330,6 +326,290 @@ export class EvalRunner {
                 session_log: sessionLog
             };
         } finally {
+            await this.provider.cleanup(workspace);
+        }
+    }
+
+    private async runInteractiveTrial(
+        agent: BaseAgent,
+        taskPath: string,
+        skillsPaths: string[],
+        opts: EvalRunOptions,
+        index: number,
+        total: number,
+        env?: Record<string, string>
+    ): Promise<TrialResult> {
+        const sessionLog: LogEntry[] = [];
+        const startTime = Date.now();
+
+        const spinner = new Spinner(`${index + 1}/${total}`, 'setting up environment');
+        const workspace = await this.provider.setup(taskPath, skillsPaths, opts, env);
+
+        try {
+            if (agent instanceof ClaudeStreamAgent) {
+                agent.start(workspace);
+            }
+
+            const instruction = opts.instruction;
+            const interactiveConfig = opts.interactive!;
+
+            sessionLog.push({
+                type: 'agent_start',
+                timestamp: this.timestamp(),
+                instruction,
+                task_path: path.resolve(taskPath),
+                workspace_path: workspace,
+            });
+
+            spinner.update('running interactive session');
+
+            const logEntry = (entry: LogEntry) => {
+                sessionLog.push(entry);
+            };
+
+            const injectorManager = new InputInjectorManager(
+                interactiveConfig,
+                opts.taskPath || taskPath
+            );
+
+            const session = new InteractiveSession(
+                agent,
+                injectorManager,
+                interactiveConfig,
+                workspace,
+                async (cmd: string) => {
+                    return this.provider.runCommand(workspace, cmd, env);
+                },
+                logEntry
+            );
+
+            const timeoutPerTurn = interactiveConfig.timeout_per_turn || opts.timeoutSec;
+            const maxTurns = interactiveConfig.max_turns || 10;
+            const calculatedTimeout = maxTurns * timeoutPerTurn;
+            const sessionTimeoutSec = Math.max(opts.timeoutSec, calculatedTimeout);
+            const sessionTimeoutMs = sessionTimeoutSec * 1000;
+
+            let sessionResult;
+            let sessionTimeoutError: string | null = null;
+            try {
+                sessionResult = await withTimeout(
+                    session.run(instruction),
+                    sessionTimeoutMs,
+                    `Interactive session (limit: ${sessionTimeoutSec}s)`
+                );
+            } catch (timeoutErr: any) {
+                sessionTimeoutError = timeoutErr.message || String(timeoutErr);
+                spinner.update('session timed out, grading partial results...');
+            }
+
+            const turns = session.getTurns();
+            const conversation = session.getConversation();
+            const commandCount = turns.reduce((sum, t) => sum + t.commands_executed, 0);
+            const totalTurns = turns.length;
+            const finalOutput = turns.length > 0 ? turns[turns.length - 1].output : (sessionTimeoutError || '');
+
+            sessionLog.push({
+                type: 'agent_result',
+                timestamp: this.timestamp(),
+                duration_ms: Date.now() - startTime,
+                output: sessionTimeoutError ? `[TIMEOUT] ${sessionTimeoutError}\n\n${finalOutput}` : finalOutput,
+            });
+
+            if (sessionTimeoutError) {
+                sessionLog.push({
+                    type: 'error',
+                    timestamp: this.timestamp(),
+                    error_type: 'TimeoutError',
+                    error_message: sessionTimeoutError,
+                    output: sessionTimeoutError,
+                });
+            }
+
+            // Run graders (even on timeout)
+            const graderResults: GraderResult[] = [];
+            // Attach turns/conversation for LLM grader multi-turn support
+            (sessionLog as any).turns = turns;
+            (sessionLog as any).conversation = conversation;
+
+            for (let gIdx = 0; gIdx < opts.graders.length; gIdx++) {
+                const graderDef = opts.graders[gIdx];
+                const grader = getGrader(graderDef.type);
+                spinner.update(`grading (${graderDef.type}${opts.graders.length > 1 ? ` ${gIdx + 1}/${opts.graders.length}` : ''})`);
+
+                const detIndex = opts.graders.slice(0, gIdx).filter(g => g.type === 'deterministic').length;
+                const llmIndex = opts.graders.slice(0, gIdx).filter(g => g.type === 'llm_rubric').length;
+
+                const graderConfig = {
+                    type: graderDef.type,
+                    command: graderDef.type === 'deterministic'
+                        ? `bash tests/${detIndex === 0 ? 'test.sh' : `test_${detIndex}.sh`}`
+                        : undefined,
+                    rubric: graderDef.type === 'llm_rubric'
+                        ? `prompts/${llmIndex === 0 ? 'quality.md' : `quality_${llmIndex}.md`}`
+                        : undefined,
+                    model: graderDef.model || opts.graderModel,
+                    provider: graderDef.provider || opts.graderProvider,
+                    weight: graderDef.weight,
+                };
+
+                const graderTimeoutMs = (opts.graderTimeoutSec ?? 120) * 1000;
+                const result = await withTimeout(
+                    grader.grade(workspace, this.provider, graderConfig, taskPath, sessionLog, env),
+                    graderTimeoutMs,
+                    `Grader ${graderDef.type} (limit: ${opts.graderTimeoutSec ?? 120}s)`
+                );
+                graderResults.push(result);
+
+                sessionLog.push({
+                    type: 'grader',
+                    timestamp: this.timestamp(),
+                    duration_ms: Date.now() - startTime,
+                    grader_result: result,
+                });
+            }
+
+            const totalWeight = graderResults.reduce((sum, r) => sum + r.weight, 0);
+            const reward = totalWeight > 0
+                ? graderResults.reduce((sum, r) => sum + r.score * r.weight, 0) / totalWeight
+                : 0;
+
+            sessionLog.push({
+                type: 'reward',
+                timestamp: this.timestamp(),
+                value: reward,
+            });
+
+            const duration_ms = Date.now() - startTime;
+
+            const input_tokens = estimateTokens(instruction);
+            const output_tokens = turns.reduce(
+                (sum, t) => sum + estimateTokens(t.input) + estimateTokens(t.output), 0
+            );
+
+            const allSkillsTriggered = session.getSkillsTriggered();
+            const allToolsUsed = session.getToolsUsed();
+
+            const status = reward >= 0.5 ? fmt.pass('PASS') : fmt.fail('FAIL');
+            const timeoutHint = sessionTimeoutError ? fmt.dim(' (timeout)') : '';
+            const skillHint = allSkillsTriggered.length > 0
+                ? `  ${fmt.dim(allSkillsTriggered.map(s => s.name).join(', '))}`
+                : '';
+            spinner.stop(`${status}${timeoutHint}  ${fmt.bold(reward.toFixed(2))}  ${fmt.dim((duration_ms / 1000).toFixed(1) + 's')}  ${fmt.dim(totalTurns + ' turns')}  ${fmt.dim(commandCount + ' cmds')}${skillHint}`);
+
+            return {
+                trial_id: index + 1,
+                reward,
+                grader_results: graderResults,
+                duration_ms,
+                n_commands: commandCount,
+                input_tokens,
+                output_tokens,
+                session_log: sessionLog,
+                skills_triggered: allSkillsTriggered,
+                tools_used: allToolsUsed,
+                turns,
+                conversation,
+            };
+        } catch (err: any) {
+            const duration_ms = Date.now() - startTime;
+            const errorMsg = err?.message || String(err);
+            const errorStack = err?.stack || '';
+            spinner.stop(`${fmt.fail('FAIL')}  ${errorMsg.substring(0, 50)}  ${fmt.dim((duration_ms / 1000).toFixed(1) + 's')}`);
+
+            let diagnostics = '';
+            if (this.provider.diagnose) {
+                try {
+                    diagnostics = await this.provider.diagnose(workspace);
+                    console.log(diagnostics);
+                } catch (e) {
+                    diagnostics = `(diagnostics failed: ${e})`;
+                }
+            }
+
+            sessionLog.push({
+                type: 'error',
+                timestamp: this.timestamp(),
+                error_type: err?.constructor?.name || 'Error',
+                error_message: errorMsg,
+                output: diagnostics ? `${errorMsg}\n\nDiagnostics:\n${diagnostics}` : errorMsg,
+            });
+
+            // Attempt grading even on error (best-effort)
+            try {
+                const graderResults: GraderResult[] = [];
+                for (let gIdx = 0; gIdx < opts.graders.length; gIdx++) {
+                    const graderDef = opts.graders[gIdx];
+                    const grader = getGrader(graderDef.type);
+
+                    const detIndex = opts.graders.slice(0, gIdx).filter(g => g.type === 'deterministic').length;
+                    const llmIndex = opts.graders.slice(0, gIdx).filter(g => g.type === 'llm_rubric').length;
+
+                    const graderConfig = {
+                        type: graderDef.type,
+                        command: graderDef.type === 'deterministic'
+                            ? `bash tests/${detIndex === 0 ? 'test.sh' : `test_${detIndex}.sh`}`
+                            : undefined,
+                        rubric: graderDef.type === 'llm_rubric'
+                            ? `prompts/${llmIndex === 0 ? 'quality.md' : `quality_${llmIndex}.md`}`
+                            : undefined,
+                        model: graderDef.model || opts.graderModel,
+                        provider: graderDef.provider || opts.graderProvider,
+                        weight: graderDef.weight,
+                    };
+
+                    const graderTimeoutMs = (opts.graderTimeoutSec ?? 120) * 1000;
+                    const result = await withTimeout(
+                        grader.grade(workspace, this.provider, graderConfig, taskPath, sessionLog, env),
+                        graderTimeoutMs,
+                        `Grader ${graderDef.type} (limit: ${opts.graderTimeoutSec ?? 120}s)`
+                    );
+                    graderResults.push(result);
+                }
+
+                const totalWeight = graderResults.reduce((sum, r) => sum + r.weight, 0);
+                const reward = totalWeight > 0
+                    ? graderResults.reduce((sum, r) => sum + r.score * r.weight, 0) / totalWeight
+                    : 0;
+
+                sessionLog.push({
+                    type: 'reward',
+                    timestamp: this.timestamp(),
+                    value: reward,
+                });
+
+                return {
+                    trial_id: index + 1,
+                    reward,
+                    grader_results: graderResults,
+                    duration_ms,
+                    n_commands: 0,
+                    input_tokens: estimateTokens(opts.instruction),
+                    output_tokens: 0,
+                    session_log: sessionLog,
+                };
+            } catch {
+                sessionLog.push({
+                    type: 'reward',
+                    timestamp: this.timestamp(),
+                    value: 0,
+                    output: diagnostics ? `${errorMsg}\n\nDiagnostics:\n${diagnostics}` : errorMsg,
+                });
+
+                return {
+                    trial_id: index + 1,
+                    reward: 0,
+                    grader_results: [],
+                    duration_ms,
+                    n_commands: 0,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    session_log: sessionLog,
+                };
+            }
+        } finally {
+            if (agent instanceof ClaudeStreamAgent && agent.isRunning()) {
+                agent.close();
+            }
             await this.provider.cleanup(workspace);
         }
     }

--- a/src/graders/index.ts
+++ b/src/graders/index.ts
@@ -1,4 +1,4 @@
-import { GraderConfig, GraderResult, EnvironmentProvider } from '../types';
+import { GraderConfig, GraderResult, EnvironmentProvider, TurnResult, ConversationMessage } from '../types';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
@@ -126,19 +126,47 @@ export class LLMGrader implements Grader {
             sections.push(`## Task Instruction\n${instructionEntry.instruction}`);
         }
 
-        // Include all commands and their output
-        const commandEntries = sessionLog.filter(e => e.type === 'command');
-        if (commandEntries.length > 0) {
-            const cmds = commandEntries.map(e =>
-                `$ ${e.command}\n${e.stdout || ''}${e.stderr ? '\nSTDERR: ' + e.stderr : ''}\n[exit code: ${e.exitCode ?? 'unknown'}]`
-            ).join('\n\n');
-            sections.push(`## Commands Executed\n${cmds}`);
-        }
+        // Check for multi-turn conversation data
+        const turnsData = (sessionLog as any).turns as TurnResult[] | undefined;
+        const conversationData = (sessionLog as any).conversation as ConversationMessage[] | undefined;
 
-        // Include agent output
-        const agentEntry = sessionLog.find(e => e.type === 'agent_result');
-        if (agentEntry?.output) {
-            sections.push(`## Agent Output\n${agentEntry.output}`);
+        if (turnsData && turnsData.length > 0) {
+            sections.push(`## Multi-Turn Conversation (${turnsData.length} turns)`);
+
+            for (const turn of turnsData) {
+                const turnHeader = `### Turn ${turn.turn_id} [${turn.status}]`;
+                const inputSection = `**User Input:**\n${turn.input}`;
+                const outputSection = `**Agent Output:**\n${turn.output.substring(0, 2000)}${turn.output.length > 2000 ? '...(truncated)' : ''}`;
+
+                let turnSection = `${turnHeader}\n\n${inputSection}\n\n${outputSection}`;
+
+                if (turn.needs_input_hint) {
+                    turnSection += `\n\n*Agent requested: ${turn.needs_input_type || 'input'} - ${turn.needs_input_hint}*`;
+                }
+
+                sections.push(turnSection);
+            }
+
+            if (conversationData && conversationData.length > 0) {
+                const conversationText = conversationData.map(msg =>
+                    `**${msg.role.toUpperCase()}:** ${msg.content.substring(0, 500)}${msg.content.length > 500 ? '...(truncated)' : ''}`
+                ).join('\n\n');
+                sections.push(`## Full Conversation History\n${conversationText}`);
+            }
+        } else {
+            // Single-turn mode: original logic
+            const commandEntries = sessionLog.filter(e => e.type === 'command');
+            if (commandEntries.length > 0) {
+                const cmds = commandEntries.map(e =>
+                    `$ ${e.command}\n${e.stdout || ''}${e.stderr ? '\nSTDERR: ' + e.stderr : ''}\n[exit code: ${e.exitCode ?? 'unknown'}]`
+                ).join('\n\n');
+                sections.push(`## Commands Executed\n${cmds}`);
+            }
+
+            const agentEntry = sessionLog.find(e => e.type === 'agent_result');
+            if (agentEntry?.output) {
+                sections.push(`## Agent Output\n${agentEntry.output}`);
+            }
         }
 
         // Include results from any prior graders (e.g., deterministic tests)
@@ -154,9 +182,14 @@ export class LLMGrader implements Grader {
 
         const transcript = sections.join('\n\n');
 
+        const isMultiTurn = turnsData && turnsData.length > 0;
+        const contextHint = isMultiTurn
+            ? `IMPORTANT CONTEXT: This is a multi-turn interactive session. The agent had multiple rounds of interaction with simulated user inputs. Evaluate the entire conversation flow, including how the agent handled user feedback and adapted its responses.`
+            : `IMPORTANT CONTEXT: The agent runs inside a CLI wrapper (e.g., Gemini CLI). The agent's tool calls (file edits, shell commands) appear as text in the "Agent Output" section. This is a real execution trace, not hallucination — the "Commands Executed" section shows the CLI invocation and its captured output. The "Prior Grader Results" section shows objective automated test results that verify the actual filesystem state after the agent ran.`;
+
         const prompt = `You are an evaluation judge. Score the following agent session on a scale from 0.0 to 1.0 based on the rubric below.
 
-IMPORTANT CONTEXT: The agent runs inside a CLI wrapper (e.g., Gemini CLI). The agent's tool calls (file edits, shell commands) appear as text in the "Agent Output" section. This is a real execution trace, not hallucination — the "Commands Executed" section shows the CLI invocation and its captured output. The "Prior Grader Results" section shows objective automated test results that verify the actual filesystem state after the agent ran.
+${contextHint}
 
 ## Rubric
 ${rubric}

--- a/src/interactive/index.ts
+++ b/src/interactive/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Multi-turn interactive evaluation module
+ */
+export { InteractiveSession, SessionResult, SessionOptions } from './session';
+export { InputInjectorManager, TurnContext, SessionContext } from './injector';

--- a/src/interactive/injector.ts
+++ b/src/interactive/injector.ts
@@ -1,0 +1,202 @@
+/**
+ * Input injector manager - manages input injection logic for multi-turn interactions
+ */
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import {
+    InteractiveConfig,
+    InputInjector as InputInjectorConfig,
+    InteractionTrigger,
+} from '../core/config.types';
+
+/** Turn context for trigger condition evaluation */
+export interface TurnContext {
+    turnId: number;
+    lastOutput: string;
+    lastCommand?: string;
+    needsInput: boolean;
+    inputType?: string;
+}
+
+/** Session context with full conversation history */
+export interface SessionContext {
+    turns: TurnContext[];
+    conversation: Array<{ role: string; content: string }>;
+}
+
+export class InputInjectorManager {
+    constructor(
+        private config: InteractiveConfig,
+        private baseDir: string
+    ) {}
+
+    /**
+     * Check if input should be injected
+     * @returns Injector config if injection is needed, null otherwise
+     */
+    shouldInject(context: TurnContext): InputInjectorConfig | null {
+        if (!this.config.injections?.length) {
+            return null;
+        }
+
+        for (const injection of this.config.injections) {
+            const trigger = injection.trigger;
+
+            if (this.matchTrigger(trigger, context)) {
+                return injection.injector;
+            }
+        }
+
+        return null;
+    }
+
+    private matchTrigger(trigger: InteractionTrigger, context: TurnContext): boolean {
+        switch (trigger.type) {
+            case 'on_turn':
+                return trigger.turns?.includes(context.turnId) ?? false;
+
+            case 'on_output_contains':
+                if (!trigger.pattern) return false;
+                return context.lastOutput.includes(trigger.pattern);
+
+            case 'on_command':
+                if (!trigger.command_pattern || !context.lastCommand) return false;
+                return context.lastCommand.includes(trigger.command_pattern);
+
+            case 'on_needs_input':
+                if (!context.needsInput) return false;
+                if (trigger.input_type && trigger.input_type !== context.inputType) {
+                    return false;
+                }
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    async getInjectContent(injector: InputInjectorConfig, turnId: number): Promise<string> {
+        switch (injector.type) {
+            case 'static':
+                return injector.content || '';
+
+            case 'file':
+                if (!injector.file) return '';
+                const filePath = injector.file
+                    .replace(/{turn}/g, String(turnId))
+                    .replace(/{TURN}/g, String(turnId));
+                const fullPath = path.resolve(this.baseDir, filePath);
+                try {
+                    if (await fs.pathExists(fullPath)) {
+                        return (await fs.readFile(fullPath, 'utf-8')).trim();
+                    }
+                } catch (err) {
+                    console.warn(`Failed to read injection file: ${fullPath}`, err);
+                }
+                return '';
+
+            case 'dynamic':
+                if (!injector.script) return '';
+                console.warn('Dynamic injector not yet implemented');
+                return '';
+
+            default:
+                return '';
+        }
+    }
+
+    /**
+     * @deprecated Use matchAllOutputPatterns instead
+     */
+    matchOutputPattern(output: string): string | null {
+        const allMatches = this.matchAllOutputPatterns(output);
+        return allMatches.length > 0 ? allMatches[0].response : null;
+    }
+
+    matchAllOutputPatterns(output: string): Array<{ pattern: string; response: string; type?: string }> {
+        const patterns = this.config.input_requests?.patterns || [];
+        const matches: Array<{ pattern: string; response: string; type?: string }> = [];
+
+        for (const p of patterns) {
+            try {
+                const regex = new RegExp(p.pattern, 'i');
+                if (regex.test(output)) {
+                    matches.push({
+                        pattern: p.pattern,
+                        response: p.response,
+                        type: p.type,
+                    });
+                }
+            } catch {
+                if (output.includes(p.pattern)) {
+                    matches.push({
+                        pattern: p.pattern,
+                        response: p.response,
+                        type: p.type,
+                    });
+                }
+            }
+        }
+
+        return matches;
+    }
+
+    getAutoResponse(inputType: string): string | null {
+        const patterns = this.config.input_requests?.patterns || [];
+
+        for (const p of patterns) {
+            try {
+                const regex = new RegExp(p.pattern, 'i');
+                if (regex.test(inputType) || inputType.toLowerCase() === p.type.toLowerCase()) {
+                    return p.response;
+                }
+            } catch {
+                if (inputType.toLowerCase() === p.type.toLowerCase()) {
+                    return p.response;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    checkStopConditions(context: TurnContext): { shouldStop: boolean; reason?: string } {
+        const conditions = this.config.stop_conditions || [];
+
+        for (const condition of conditions) {
+            switch (condition.type) {
+                case 'output_matches':
+                    if (condition.pattern && context.lastOutput.includes(condition.pattern)) {
+                        return { shouldStop: true, reason: `Output matches: ${condition.pattern}` };
+                    }
+                    break;
+
+                case 'command_executed':
+                    if (condition.command && context.lastCommand?.includes(condition.command)) {
+                        return { shouldStop: true, reason: `Command executed: ${condition.command}` };
+                    }
+                    break;
+
+                case 'turns_reached':
+                    if (condition.turns && context.turnId >= condition.turns) {
+                        return { shouldStop: true, reason: `Max turns reached: ${condition.turns}` };
+                    }
+                    break;
+            }
+        }
+
+        return { shouldStop: false };
+    }
+
+    getMaxTurns(): number {
+        return this.config.max_turns || 10;
+    }
+
+    getTimeoutPerTurn(): number | undefined {
+        return this.config.timeout_per_turn;
+    }
+
+    isEnabled(): boolean {
+        return this.config.enabled;
+    }
+}

--- a/src/interactive/session.ts
+++ b/src/interactive/session.ts
@@ -1,0 +1,348 @@
+/**
+ * Session executor - manages the execution flow of multi-turn interactive evaluation
+ */
+import { BaseAgent, CommandResult, ConversationMessage, TurnResult, LogEntry, AgentResult, SkillTriggerInfo } from '../types';
+import { InteractiveConfig, ContextConfig } from '../core/config.types';
+import { InputInjectorManager, TurnContext } from './injector';
+import { parseOutputMarkers } from '../utils/markers';
+import { withTimeout } from '../utils/timeout';
+import { ClaudeStreamAgent } from '../agents/claude-stream';
+
+type RunCommandFn = (cmd: string, env?: Record<string, string>) => Promise<CommandResult>;
+
+const DEFAULT_CONTEXT_CONFIG: ContextConfig = {
+    max_history_turns: 10,
+    include_system_prompt: false,
+};
+
+export interface SessionResult {
+    turns: TurnResult[];
+    conversation: ConversationMessage[];
+    totalTurns: number;
+    finalOutput: string;
+}
+
+export interface SessionOptions {
+    instruction: string;
+    workspace: string;
+    timeoutPerTurn?: number;
+    maxTurns: number;
+}
+
+export class InteractiveSession {
+    private turnCount = 0;
+    private conversation: ConversationMessage[] = [];
+    private turns: TurnResult[] = [];
+    private lastCommand: string = '';
+    private commandCount = 0;
+    private contextConfig: ContextConfig;
+    private initialInstruction: string = '';
+    private skillsTriggered: SkillTriggerInfo[] = [];
+    private toolsUsed = new Set<string>();
+
+    constructor(
+        private agent: BaseAgent,
+        private injectorManager: InputInjectorManager,
+        private config: InteractiveConfig,
+        private workspace: string,
+        private runCommand: RunCommandFn,
+        private logEntry: (entry: LogEntry) => void
+    ) {
+        this.contextConfig = { ...DEFAULT_CONTEXT_CONFIG, ...config.context };
+    }
+
+    private buildPromptWithHistory(currentInput: string): string {
+        const parts: string[] = [];
+
+        if (this.contextConfig.include_system_prompt && this.contextConfig.system_prompt) {
+            parts.push(`[System]\n${this.contextConfig.system_prompt}`);
+            parts.push('');
+        }
+
+        const maxHistoryTurns = this.contextConfig.max_history_turns || 10;
+
+        if (this.turnCount === 1 && this.initialInstruction) {
+            parts.push(`[Initial Task]\n${this.initialInstruction}`);
+            parts.push('');
+        }
+
+        const historyMessages = this.conversation.slice(0, -1).slice(-(maxHistoryTurns * 2));
+
+        if (historyMessages.length > 0) {
+            parts.push('[Conversation History]');
+            for (const msg of historyMessages) {
+                const role = msg.role === 'user' ? 'User' : 'Assistant';
+                parts.push(`${role}: ${msg.content}`);
+            }
+            parts.push('');
+        }
+
+        if (this.turnCount === 1) {
+            parts.push('[Your Response]');
+        } else {
+            parts.push(`[Current Input]\n${currentInput}`);
+        }
+
+        return parts.join('\n');
+    }
+
+    async run(initialInstruction: string): Promise<SessionResult> {
+        this.initialInstruction = initialInstruction;
+        let currentInput = initialInstruction;
+
+        while (this.turnCount < this.injectorManager.getMaxTurns()) {
+            this.turnCount++;
+
+            this.logEntry({
+                type: 'turn_start',
+                timestamp: new Date().toISOString(),
+                turn_id: this.turnCount,
+                instruction: currentInput,
+            });
+
+            const turnResult = await this.runTurn(currentInput);
+            this.turns.push(turnResult);
+
+            if (turnResult.status === 'timeout' || turnResult.status === 'error') {
+                this.logEntry({
+                    type: 'turn_end',
+                    timestamp: new Date().toISOString(),
+                    turn_id: this.turnCount,
+                    duration_ms: turnResult.duration_ms,
+                    output: turnResult.output,
+                });
+                break;
+            }
+
+            this.logEntry({
+                type: 'turn_end',
+                timestamp: new Date().toISOString(),
+                turn_id: this.turnCount,
+                duration_ms: turnResult.duration_ms,
+                output: turnResult.output,
+            });
+
+            const stopCheck = this.injectorManager.checkStopConditions({
+                turnId: this.turnCount,
+                lastOutput: turnResult.output,
+                lastCommand: this.lastCommand,
+                needsInput: turnResult.status === 'needs_input',
+                inputType: turnResult.needs_input_type,
+            });
+
+            if (stopCheck.shouldStop) {
+                break;
+            }
+
+            const nextInput = await this.getNextInput(turnResult);
+            if (!nextInput) {
+                break;
+            }
+
+            this.logEntry({
+                type: 'input_injected',
+                timestamp: new Date().toISOString(),
+                turn_id: this.turnCount,
+                input_type: 'injected',
+                input_content: nextInput,
+            });
+
+            currentInput = nextInput;
+        }
+
+        const lastTurn = this.turns[this.turns.length - 1];
+
+        return {
+            turns: this.turns,
+            conversation: this.conversation,
+            totalTurns: this.turnCount,
+            finalOutput: lastTurn?.output || '',
+        };
+    }
+
+    private async runTurn(input: string): Promise<TurnResult> {
+        const startTime = Date.now();
+        const startCommandCount = this.commandCount;
+
+        this.conversation.push({
+            role: 'user',
+            content: input,
+            timestamp: new Date().toISOString(),
+        });
+
+        const loggedRunCommand = async (cmd: string, env?: Record<string, string>): Promise<CommandResult> => {
+            this.lastCommand = cmd;
+            this.commandCount++;
+
+            const cmdStartTime = Date.now();
+            const result = await this.runCommand(cmd, env);
+            const cmdDuration = Date.now() - cmdStartTime;
+
+            this.logEntry({
+                type: 'command',
+                timestamp: new Date().toISOString(),
+                duration_ms: cmdDuration,
+                command: cmd,
+                cwd: this.workspace,
+                stdout: result.stdout,
+                stderr: result.stderr,
+                exitCode: result.exitCode,
+            });
+
+            return result;
+        };
+
+        const timeoutPerTurnSec = this.injectorManager.getTimeoutPerTurn() || 300;
+        const turnTimeoutMs = timeoutPerTurnSec * 1000;
+
+        let output: string;
+        try {
+            let agentRaw: string | AgentResult;
+
+            if (this.agent instanceof ClaudeStreamAgent) {
+                agentRaw = await withTimeout(
+                    this.agent.sendMessage(input),
+                    turnTimeoutMs,
+                    `Turn ${this.turnCount} (limit: ${timeoutPerTurnSec}s)`
+                );
+            } else {
+                const promptWithHistory = this.buildPromptWithHistory(input);
+                agentRaw = await withTimeout(
+                    this.agent.run(promptWithHistory, this.workspace, loggedRunCommand),
+                    turnTimeoutMs,
+                    `Turn ${this.turnCount} (limit: ${timeoutPerTurnSec}s)`
+                );
+            }
+
+            if (typeof agentRaw === 'string') {
+                output = agentRaw;
+            } else {
+                output = agentRaw.output;
+                for (const skill of agentRaw.skills_triggered) {
+                    const key = `${skill.source}:${skill.name}`;
+                    if (!this.skillsTriggered.some(s => `${s.source}:${s.name}` === key)) {
+                        this.skillsTriggered.push(skill);
+                    }
+                }
+                for (const tool of agentRaw.tools_used) {
+                    this.toolsUsed.add(tool);
+                }
+            }
+        } catch (error: any) {
+            const duration = Date.now() - startTime;
+            const errorMsg = error.message || String(error);
+            const isTimeout = errorMsg.includes('timed out');
+
+            let partialOutput = errorMsg;
+            let partialSkills: SkillTriggerInfo[] | undefined;
+            let partialTools: string[] | undefined;
+
+            if (this.agent instanceof ClaudeStreamAgent) {
+                const partial = this.agent.getPartialResult();
+                partialOutput = partial.output || errorMsg;
+                partialSkills = partial.skills_triggered;
+                partialTools = partial.tools_used;
+
+                for (const skill of partial.skills_triggered) {
+                    const key = `${skill.source}:${skill.name}`;
+                    if (!this.skillsTriggered.some(s => `${s.source}:${s.name}` === key)) {
+                        this.skillsTriggered.push(skill);
+                    }
+                }
+                for (const tool of partial.tools_used) {
+                    this.toolsUsed.add(tool);
+                }
+
+                if (isTimeout) {
+                    this.agent.close();
+                }
+            }
+
+            this.conversation.push({
+                role: 'assistant',
+                content: partialOutput,
+                timestamp: new Date().toISOString(),
+            });
+
+            return {
+                turn_id: this.turnCount,
+                input,
+                output: partialOutput,
+                status: isTimeout ? 'timeout' : 'error',
+                commands_executed: this.commandCount - startCommandCount,
+                duration_ms: duration,
+                skills_triggered: partialSkills,
+                tools_used: partialTools,
+            };
+        }
+
+        const duration = Date.now() - startTime;
+
+        this.conversation.push({
+            role: 'assistant',
+            content: output,
+            timestamp: new Date().toISOString(),
+        });
+
+        const markers = parseOutputMarkers(output);
+
+        return {
+            turn_id: this.turnCount,
+            input,
+            output,
+            status: markers.needsInput ? 'needs_input' : 'completed',
+            needs_input_type: markers.inputType,
+            needs_input_hint: markers.inputHint,
+            commands_executed: this.commandCount - startCommandCount,
+            duration_ms: duration,
+        };
+    }
+
+    private async getNextInput(turnResult: TurnResult): Promise<string | null> {
+        const injector = this.injectorManager.shouldInject({
+            turnId: this.turnCount,
+            lastOutput: turnResult.output,
+            lastCommand: this.lastCommand,
+            needsInput: turnResult.status === 'needs_input',
+            inputType: turnResult.needs_input_type,
+        });
+
+        if (injector) {
+            return await this.injectorManager.getInjectContent(injector, this.turnCount);
+        }
+
+        const allMatches = this.injectorManager.matchAllOutputPatterns(turnResult.output);
+        if (allMatches.length > 0) {
+            return allMatches.map(m => m.response).join('\n');
+        }
+
+        if (turnResult.status === 'needs_input' && turnResult.needs_input_type) {
+            const autoResponse = this.injectorManager.getAutoResponse(turnResult.needs_input_type);
+            if (autoResponse) {
+                return autoResponse;
+            }
+        }
+
+        return null;
+    }
+
+    getCurrentTurn(): number {
+        return this.turnCount;
+    }
+
+    getConversation(): ConversationMessage[] {
+        return [...this.conversation];
+    }
+
+    getTurns(): TurnResult[] {
+        return [...this.turns];
+    }
+
+    getSkillsTriggered(): SkillTriggerInfo[] {
+        return [...this.skillsTriggered];
+    }
+
+    getToolsUsed(): string[] {
+        return Array.from(this.toolsUsed);
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface GraderResult {
 }
 
 export interface LogEntry {
-    type: 'agent_start' | 'command' | 'agent_result' | 'grader' | 'reward';
+    type: 'agent_start' | 'command' | 'agent_result' | 'grader' | 'reward' | 'turn_start' | 'turn_end' | 'input_injected' | 'error';
     timestamp: string;
     instruction?: string;
     command?: string;
@@ -31,6 +31,15 @@ export interface LogEntry {
     output?: string;
     value?: number;
     grader_result?: GraderResult;
+    duration_ms?: number;
+    turn_id?: number;
+    input_type?: string;
+    input_content?: string;
+    cwd?: string;
+    error_type?: string;
+    error_message?: string;
+    task_path?: string;
+    workspace_path?: string;
 }
 
 export interface TrialResult {
@@ -45,6 +54,9 @@ export interface TrialResult {
     // Skill trigger tracking
     skills_triggered?: SkillTriggerInfo[];  // List of triggered skills
     tools_used?: string[];                  // List of tools used
+    // Multi-turn interactive session data
+    turns?: TurnResult[];
+    conversation?: ConversationMessage[];
 }
 
 /** Skill trigger information during agent execution */
@@ -64,6 +76,27 @@ export interface AgentResult {
     num_turns?: number;                     // Number of API interaction turns
     duration_api_ms?: number;               // API duration in milliseconds
     cost_usd?: number;                      // Cost in USD
+}
+
+/** Conversation message for multi-turn sessions */
+export interface ConversationMessage {
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+    timestamp: string;
+}
+
+/** Single turn execution result */
+export interface TurnResult {
+    turn_id: number;
+    input: string;
+    output: string;
+    status: 'completed' | 'needs_input' | 'timeout' | 'error';
+    needs_input_type?: string;
+    needs_input_hint?: string;
+    commands_executed: number;
+    duration_ms: number;
+    skills_triggered?: SkillTriggerInfo[];
+    tools_used?: string[];
 }
 
 export interface EvalReport {

--- a/src/utils/markers.ts
+++ b/src/utils/markers.ts
@@ -1,0 +1,130 @@
+/**
+ * Marker parser - parses interactive markers from agent output
+ *
+ * Supported marker formats:
+ * - [NEEDS_INPUT:type] hint text
+ * - [WAITING_FOR_USER] hint text
+ * - [AWAITING_CONFIRMATION] hint text
+ * - Chinese markers (see patterns below)
+ */
+
+export interface ParsedMarker {
+    needsInput: boolean;
+    inputType?: string;
+    inputHint?: string;
+}
+
+/** Predefined marker patterns */
+const MARKER_PATTERNS: Array<{
+    pattern: RegExp;
+    typeExtractor: (match: RegExpMatchArray) => { type: string; hint: string };
+}> = [
+    // [NEEDS_INPUT:confirmation] Please confirm?
+    {
+        pattern: /\[NEEDS_INPUT:(\w+)\]\s*(.*)/i,
+        typeExtractor: (m) => ({ type: m[1].toLowerCase(), hint: m[2].trim() }),
+    },
+    // [WAITING_FOR_USER] Waiting for user input...
+    {
+        pattern: /\[WAITING_FOR_USER\]\s*(.*)/i,
+        typeExtractor: (m) => ({ type: 'generic', hint: m[1].trim() }),
+    },
+    // [AWAITING_CONFIRMATION] Please confirm...
+    {
+        pattern: /\[AWAITING_CONFIRMATION\]\s*(.*)/i,
+        typeExtractor: (m) => ({ type: 'confirmation', hint: m[1].trim() }),
+    },
+    // [AWAITING_CHOICE] Please select...
+    {
+        pattern: /\[AWAITING_CHOICE\]\s*(.*)/i,
+        typeExtractor: (m) => ({ type: 'choice', hint: m[1].trim() }),
+    },
+    // Chinese: waiting for user confirmation
+    {
+        pattern: /等待用户确认[：:]\s*(.*)/,
+        typeExtractor: (m) => ({ type: 'confirmation', hint: m[1].trim() }),
+    },
+    // Chinese: waiting for user input
+    {
+        pattern: /等待用户输入[：:]\s*(.*)/,
+        typeExtractor: (m) => ({ type: 'generic', hint: m[1].trim() }),
+    },
+    // Chinese: waiting for user selection
+    {
+        pattern: /等待用户选择[：:]\s*(.*)/,
+        typeExtractor: (m) => ({ type: 'choice', hint: m[1].trim() }),
+    },
+    // Chinese: please confirm whether...
+    {
+        pattern: /请确认(是否|如下)[：:.]?\s*(.*)/i,
+        typeExtractor: (m) => ({ type: 'confirmation', hint: m[0].trim() }),
+    },
+    // Chinese: please select...
+    {
+        pattern: /请选择[：:.]?\s*(.*)/i,
+        typeExtractor: (m) => ({ type: 'choice', hint: m[0].trim() }),
+    },
+];
+
+/**
+ * Parse interactive markers from agent output
+ * @param output Agent output text
+ * @returns Parsed result
+ */
+export function parseOutputMarkers(output: string): ParsedMarker {
+    if (!output || typeof output !== 'string') {
+        return { needsInput: false };
+    }
+
+    for (const { pattern, typeExtractor } of MARKER_PATTERNS) {
+        const match = output.match(pattern);
+        if (match) {
+            const { type, hint } = typeExtractor(match);
+            return {
+                needsInput: true,
+                inputType: type,
+                inputHint: hint || undefined,
+            };
+        }
+    }
+
+    return { needsInput: false };
+}
+
+/**
+ * Check if output contains stop markers
+ * @param output Agent output text
+ * @param stopPatterns List of stop patterns
+ */
+export function checkStopConditions(
+    output: string,
+    stopPatterns: string[]
+): boolean {
+    if (!output || !stopPatterns?.length) {
+        return false;
+    }
+
+    for (const pattern of stopPatterns) {
+        if (output.includes(pattern)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Normalize input type to standard form
+ */
+export function normalizeInputType(type: string): string {
+    const typeMap: Record<string, string> = {
+        'confirm': 'confirmation',
+        'choice': 'choice',
+        'select': 'choice',
+        'input': 'generic',
+        'text': 'generic',
+        'confirmation': 'confirmation',
+        'generic': 'generic',
+    };
+    return typeMap[type.toLowerCase()] || type.toLowerCase();
+}

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,32 @@
+/**
+ * Timeout utility
+ */
+
+/**
+ * Wrap a Promise with a timeout
+ * @param promise The promise to wrap
+ * @param timeoutMs Timeout in milliseconds
+ * @param label Label for the error message
+ */
+export function withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    label: string
+): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error(`${label} timed out after ${timeoutMs / 1000}s`));
+        }, timeoutMs);
+
+        promise.then(
+            (val) => {
+                clearTimeout(timer);
+                resolve(val);
+            },
+            (err) => {
+                clearTimeout(timer);
+                reject(err);
+            }
+        );
+    });
+}

--- a/templates/eval.yaml.template
+++ b/templates/eval.yaml.template
@@ -11,7 +11,7 @@
 version: "1"
 
 defaults:
-  agent: gemini          # gemini | claude | codex | acp | opencode
+  agent: gemini          # gemini | claude | claude-stream | codex | acp | opencode
   provider: docker       # docker | local (use local for quick iteration)
   trials: 5              # number of independent runs per task
   timeout: 300           # seconds before agent is killed
@@ -59,3 +59,17 @@ tasks:
 
     # Optional: reference solution for --validate
     # solution: solutions/solve.sh
+
+    # Optional: multi-turn interactive evaluation
+    # interactive:
+    #   enabled: true
+    #   max_turns: 5
+    #   timeout_per_turn: 60
+    #   input_requests:
+    #     patterns:
+    #       - pattern: "\\[NEEDS_INPUT:confirmation\\]"
+    #         type: confirmation
+    #         response: "YES"
+    #   stop_conditions:
+    #     - type: output_matches
+    #       pattern: "[TASK COMPLETED]"


### PR DESCRIPTION
Add multi-turn conversation evaluation where agents can engage in iterative dialogue with simulated user inputs. Key components:

- InteractiveSession: orchestrates multi-turn conversation execution
- InputInjectorManager: manages input injection, pattern matching, and stop conditions
- ClaudeStreamAgent: persistent streaming agent for true multi-turn conversations via stream-json protocol
- Output marker parser for agent signals ([NEEDS_INPUT:type], etc.)
- LLM grader support for multi-turn transcripts with context-aware hints
- Auto-switch from claude to claude-stream when interactive is enabled
- Error-path grading: attempts evaluation even when agent setup fails

Includes eval.yaml configuration reference, interactive-demo example, and template updates.