### PR TITLE
feat: support custom CLI agents via a `command` agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ Reports are saved to `$TMPDIR/skillgrade/<skill-name>/results/`. Override with `
 | `--grader=TYPE` | Run only graders of a type (`deterministic` or `llm_rubric`) |
 | `--trials=N` | Override trial count |
 | `--parallel=N` | Run trials concurrently |
-| `--agent=gemini\|claude\|codex\|acp\|opencode` | Override agent (default: auto-detect from API key) |
+| `--agent=gemini\|claude\|codex\|acp\|opencode\|command` | Override agent (default: auto-detect from API key) |
 | `--provider=docker\|local` | Override provider |
 | `--acp-command=CMD` | ACP agent command (e.g., `gemini --acp`) |
+| `--command=CMD` | Command to run for the `command` agent (e.g., `node mycli.js`) |
 | `--opencode-agent=NAME` | OpenCode agent (build\|plan\|explore) |
 | `--opencode-model=MODEL` | OpenCode model (provider/model format) |
 | `--output=DIR` | Output directory (default: `$TMPDIR/skillgrade`) |
@@ -79,13 +80,14 @@ version: "1"
 # skill: path/to/my-skill
 
 defaults:
-  agent: gemini          # gemini | claude | codex | acp | opencode
+  agent: gemini          # gemini | claude | codex | acp | opencode | command
   provider: docker       # docker | local
   trials: 5
   timeout: 300           # seconds
   threshold: 0.8         # for --ci mode
   grader_model: gemini-3-flash-preview  # default LLM grader model
   grader_provider: gemini               # default LLM grader provider: gemini | anthropic | openai
+  command: node mycli.js # command to run when agent is 'command' (see Custom Command Agent)
   acp:                   # ACP agent configuration (optional)
     command: gemini --acp  # command to start ACP-compatible agent
     env:                  # optional environment variables
@@ -252,6 +254,47 @@ Exits with code 1 if pass rate falls below `--threshold` (default: 0.8).
 | `OPENAI_BASE_URL` | LLM grading (`provider: openai`) — custom OpenAI-compatible endpoint (Ollama, vLLM, etc.) |
 
 Variables are also loaded from `.env` in the skill directory. Shell values override `.env`. All values are **redacted** from persisted session logs.
+
+## Custom Command Agent
+
+Bring your own agent. The built-in adapters (`gemini`, `claude`, `codex`, ...) cover the popular CLIs, but you can point skillgrade at **any command** — a custom script, a [deepagents](https://github.com/langchain-ai/deepagents) loop, or a small orchestrator over the Claude/OpenAI SDKs — without forking the package or implementing an ACP server.
+
+### Quick Start
+
+```bash
+skillgrade --agent=command --command="node mycli.js"
+```
+
+Or in `eval.yaml`:
+
+```yaml
+defaults:
+  agent: command
+  command: "node mycli.js"
+  provider: local        # run on the host; or use docker + docker.setup to install your CLI
+```
+
+`command` can also be set per task to override the default.
+
+### How the instruction reaches your command
+
+The task instruction is **piped to your command's stdin** (skillgrade writes it to `/tmp/.prompt.md`, then runs `cat /tmp/.prompt.md | <command>` inside the workspace directory). If your CLI takes the prompt as an argument instead, wrap it in a one-line script that reads stdin.
+
+Your command runs in the workspace and is free to read/edit files there — graders score the resulting workspace state (and any live checks), not your command's stdout, so any agent slots in cleanly.
+
+### Docker vs local
+
+- **`provider: local`** is the simplest fit for a custom agent: your command runs on the host with your tools already installed.
+- **`provider: docker`** still works — skillgrade does **not** auto-install anything for the `command` agent, so install your CLI and dependencies via `docker.setup`:
+
+```yaml
+defaults:
+  agent: command
+  command: "mycli run"
+  docker:
+    base: node:20-slim
+    setup: "npm install -g my-cli-package"
+```
 
 ## OpenCode Agent
 

--- a/skills/skillgrade-setup/SKILL.md
+++ b/skills/skillgrade-setup/SKILL.md
@@ -37,10 +37,11 @@ description: Sets up and runs skillgrade evaluation pipelines for Agent Skills. 
 4. Run multiple evals: `skillgrade --eval=fix-linting,write-tests`.
 5. Run only deterministic graders (skip LLM calls): `skillgrade --grader=deterministic`.
 6. Run only LLM rubric graders: `skillgrade --grader=llm_rubric`.
-7. The agent is auto-detected from the API key. Override with `--agent=gemini|claude|codex|acp|opencode`.
+7. The agent is auto-detected from the API key. Override with `--agent=gemini|claude|codex|acp|opencode|command`.
 8. For ACP, pass `--acp-command="gemini --acp"` or set `defaults.acp.command`.
 9. For OpenCode, pass `--opencode-agent=build|plan|explore` or `--opencode-model=provider/model`.
-10. Override the provider with `--provider=docker|local`.
+10. For a custom agent, pass `--agent=command --command="node mycli.js"` or set `defaults.command`. The instruction is piped to the command's stdin.
+11. Override the provider with `--provider=docker|local`.
 
 **Step 5: Review Results**
 1. Run `skillgrade preview` for a CLI report.

--- a/skills/skillgrade-setup/references/eval-yaml-spec.md
+++ b/skills/skillgrade-setup/references/eval-yaml-spec.md
@@ -13,7 +13,8 @@ Configure shared settings for all tasks.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `agent` | string | auto-detect | `gemini`, `claude`, `codex`, `acp`, or `opencode` |
+| `agent` | string | auto-detect | `gemini`, `claude`, `codex`, `acp`, `opencode`, or `command` |
+| `command` | string | none | Command to run when `agent` is `command` (e.g. `node mycli.js`). Required for the `command` agent. |
 | `provider` | string | `docker` | `docker` or `local` |
 | `trials` | number | 5 | Number of evaluation trials |
 | `timeout` | number | 300 | Seconds before agent timeout |
@@ -53,6 +54,7 @@ Array of evaluation tasks. Each task has:
 | `workspace` | array | No | Files copied into the container |
 | `graders` | array | Yes | One or more grader definitions |
 | `agent` | string | No | Per-task agent override |
+| `command` | string | No | Per-task command override (for the `command` agent) |
 | `trials` | number | No | Per-task trial count override |
 | `timeout` | number | No | Per-task timeout override |
 

--- a/src/agents/command.ts
+++ b/src/agents/command.ts
@@ -1,0 +1,56 @@
+import { BaseAgent, CommandResult } from '../types';
+
+export interface CommandAgentConfig {
+    /** The command to run (e.g. "node mycli.js"). The prompt is piped to its stdin. */
+    command: string;
+    /** Optional environment variables for the command process. */
+    env?: Record<string, string>;
+}
+
+/**
+ * Generic agent that runs an arbitrary command, letting users bring their own
+ * CLI (a custom script, a deepagents loop, an SDK orchestrator) without forking
+ * the package or implementing an ACP server.
+ *
+ * The task instruction is piped to the command's stdin. Grading scores ground
+ * truth (deterministic graders / live workspace state), not stdout, so any
+ * command slots in cleanly. Returns combined stdout + stderr, like opencode.
+ */
+export class CommandAgent extends BaseAgent {
+    private config: CommandAgentConfig;
+
+    constructor(config: CommandAgentConfig) {
+        super();
+        if (!config || !config.command || !config.command.trim()) {
+            throw new Error(
+                'Command agent requires a command. Specify via --command or command in eval.yaml'
+            );
+        }
+        this.config = config;
+    }
+
+    async run(
+        instruction: string,
+        workspacePath: string,
+        runCommand: (cmd: string, env?: Record<string, string>) => Promise<CommandResult>
+    ): Promise<string> {
+        // Write the instruction to a file via base64 to avoid shell escaping
+        // issues with long or special-character prompts, then pipe it to stdin.
+        const b64 = Buffer.from(instruction).toString('base64');
+        await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
+
+        const cwd = workspacePath.replace(/'/g, "'\\''");
+        const fullCommand = `cd '${cwd}' && cat /tmp/.prompt.md | ${this.config.command}`;
+
+        const env = this.config.env && Object.keys(this.config.env).length > 0
+            ? this.config.env
+            : undefined;
+        const result = await runCommand(fullCommand, env);
+
+        if (result.exitCode !== 0) {
+            console.error('CommandAgent: command exited with a non-zero status.');
+        }
+
+        return result.stdout + '\n' + result.stderr;
+    }
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -7,6 +7,7 @@
  *   - codex: OpenAI Codex CLI
  *   - acp: Agent Client Protocol compatible agents
  *   - opencode: OpenCode AI coding agent
+ *   - command: arbitrary user-provided command (bring your own agent)
  */
 import { BaseAgent } from '../types';
 import { GeminiAgent } from './gemini';
@@ -14,6 +15,7 @@ import { ClaudeAgent } from './claude';
 import { CodexAgent } from './codex';
 import { AcpAgent, AcpAgentConfig } from './acp';
 import { OpenCodeAgent, OpenCodeAgentConfig } from './opencode';
+import { CommandAgent, CommandAgentConfig } from './command';
 
 /** Configuration for agent creation */
 export interface AgentConfig {
@@ -21,6 +23,8 @@ export interface AgentConfig {
     acp?: AcpAgentConfig;
     /** OpenCode-specific configuration */
     opencode?: OpenCodeAgentConfig;
+    /** Command agent configuration */
+    command?: CommandAgentConfig;
 }
 
 /** Registry of available agent implementations */
@@ -31,6 +35,8 @@ const AGENT_REGISTRY: Record<string, (config?: AgentConfig) => BaseAgent> = {
     // ACP agent requires config, registered as placeholder
     acp: (config) => new AcpAgent(config?.acp || { command: 'gemini --acp' }),
     opencode: (config) => new OpenCodeAgent(config?.opencode || {}),
+    // Command agent requires a command, validated in the CommandAgent constructor
+    command: (config) => new CommandAgent(config?.command as CommandAgentConfig),
 };
 
 /** Get the list of supported agent names */

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -25,11 +25,12 @@ interface RunOptions {
     ci?: boolean;
     threshold?: number;
     preset?: 'smoke' | 'reliable' | 'regression';
-    agent?: string;      // override agent (gemini|claude|codex|acp|opencode)
+    agent?: string;      // override agent (gemini|claude|codex|acp|opencode|command)
     provider?: string;   // override provider (docker|local)
     output?: string;     // output directory for reports and temp files
     grader?: string;     // filter graders by type (deterministic|llm_rubric)
     acpCommand?: string; // ACP agent command (e.g., "gemini --acp")
+    command?: string;    // command agent command (e.g., "node mycli.js")
     openCodeAgent?: string;   // OpenCode agent (build|plan|explore)
     openCodeModel?: string;   // OpenCode model (provider/model format)
 }
@@ -162,6 +163,12 @@ export async function runEvals(dir: string, opts: RunOptions) {
             if (opts.openCodeModel) {
                 agentConfig.opencode.model = opts.openCodeModel;
             }
+        } else if (agentName === 'command') {
+            const command = opts.command || resolved.command;
+            if (!command) {
+                throw new Error('Command agent requires a command. Specify via --command or command in eval.yaml');
+            }
+            agentConfig.command = { command };
         }
 
         // Pick provider
@@ -302,6 +309,8 @@ export async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string
     } else if (resolved.agent === 'opencode') {
         dockerfileContent += `RUN npm install -g opencode\n\n`;
     }
+    // The 'command' agent brings its own binary — install it via docker.setup
+    // below, or use `provider: local` to run a command on the host.
 
     // Docker setup commands
     if (resolved.docker.setup) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -115,6 +115,13 @@ function validateConfig(raw: any): EvalConfig {
             throw new Error(`Task "${t.name}" has invalid grader_provider "${t.grader_provider}", must be one of ${validGraderProviders.join(', ')}`);
         }
 
+        // The "command" agent requires a command (per-task override or inherited default)
+        const effectiveAgent = t.agent || defaults.agent;
+        const effectiveCommand = t.command || defaults.command;
+        if (effectiveAgent === 'command' && !effectiveCommand) {
+            throw new Error(`Task "${t.name}" uses the "command" agent but no command is set (add a "command" to the task or defaults)`);
+        }
+
         const workspace: WorkspaceMapping[] = (t.workspace || []).map((w: any) => {
             if (typeof w === 'string') {
                 // Support shorthand: "fixtures/app.js" → same filename in workspace
@@ -146,6 +153,7 @@ function validateConfig(raw: any): EvalConfig {
             }),
             solution: t.solution,
             agent: t.agent,
+            command: t.command,
             provider: t.provider,
             trials: t.trials,
             timeout: t.timeout,
@@ -169,6 +177,7 @@ export async function resolveTask(
 ): Promise<ResolvedTask> {
     // Merge defaults with task overrides
     const agent = task.agent || defaults.agent;
+    const command = task.command || defaults.command;
     const provider = task.provider || defaults.provider;
     const trials = task.trials ?? defaults.trials;
     const timeout = task.timeout ?? defaults.timeout;
@@ -219,6 +228,7 @@ export async function resolveTask(
         graders,
         solution,
         agent,
+        command,
         provider,
         trials,
         timeout,

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -53,6 +53,7 @@ export interface EvalTaskConfig {
 
     // Per-task overrides
     agent?: string;
+    command?: string;   // command to run when agent is 'command'
     provider?: string;
     trials?: number;
     timeout?: number;
@@ -64,7 +65,8 @@ export interface EvalTaskConfig {
 
 /** Top-level defaults */
 export interface EvalDefaults {
-    agent: string;      // 'gemini' | 'claude' | 'codex' | 'acp' | 'opencode'
+    agent: string;      // 'gemini' | 'claude' | 'codex' | 'acp' | 'opencode' | 'command'
+    command?: string;   // command to run when agent is 'command' (e.g. "node mycli.js")
     provider: string;   // 'docker' | 'local'
     trials: number;
     timeout: number;
@@ -92,6 +94,7 @@ export interface ResolvedTask {
     graders: ResolvedGrader[];
     solution?: string;      // resolved file path
     agent: string;
+    command?: string;       // command to run when agent is 'command'
     provider: string;
     trials: number;
     timeout: number;

--- a/src/skillgrade.ts
+++ b/src/skillgrade.ts
@@ -103,6 +103,7 @@ async function main() {
         grader: getFlag('grader'),
         output: outputDir,
         acpCommand: getFlag('acp-command'),
+        command: getFlag('command'),
         openCodeAgent: getFlag('opencode-agent'),
         openCodeModel: getFlag('opencode-model'),
     });
@@ -132,9 +133,10 @@ function printHelp() {
     --grader=TYPE      Run only graders of this type (deterministic|llm_rubric)
     --trials=N         Override trial count (overrides preset)
     --parallel=N       Run trials concurrently
-    --agent=gemini|claude|codex|acp|opencode   Override agent (default: auto-detect from API key)
+    --agent=gemini|claude|codex|acp|opencode|command   Override agent (default: auto-detect from API key)
     --provider=docker|local Override provider (default: docker)
     --acp-command=CMD  ACP agent command (e.g., "gemini --acp")
+    --command=CMD      Command to run for the 'command' agent (e.g., "node mycli.js")
     --opencode-agent=NAME   OpenCode agent (build|plan|explore)
     --opencode-model=MODEL OpenCode model (provider/model format)
     --output=DIR       Output directory for reports and temp files

--- a/templates/eval.yaml.template
+++ b/templates/eval.yaml.template
@@ -11,7 +11,8 @@
 version: "1"
 
 defaults:
-  agent: gemini          # gemini | claude | codex | acp | opencode
+  agent: gemini          # gemini | claude | codex | acp | opencode | command
+  # command: node mycli.js  # required when agent is 'command' — run your own agent CLI
   provider: docker       # docker | local (use local for quick iteration)
   trials: 5              # number of independent runs per task
   timeout: 300           # seconds before agent is killed

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GeminiAgent } from '../src/agents/gemini';
 import { ClaudeAgent } from '../src/agents/claude';
 import { OpenCodeAgent } from '../src/agents/opencode';
+import { CommandAgent } from '../src/agents/command';
 import { CommandResult } from '../src/types';
 
 beforeEach(() => {
@@ -173,5 +174,54 @@ describe('OpenCodeAgent', () => {
     const result = await agent.run('test', '/workspace', mockRunCommand);
     expect(result).toContain('success');
     expect(result).toContain('warning');
+  });
+});
+
+describe('CommandAgent', () => {
+  it('throws when no command is provided', () => {
+    expect(() => new CommandAgent({ command: '' })).toThrow('Command agent requires a command');
+    // @ts-expect-error - exercising the runtime guard with a missing config
+    expect(() => new CommandAgent(undefined)).toThrow('Command agent requires a command');
+  });
+
+  it('writes instruction via base64 and pipes it to the command stdin by default', async () => {
+    const agent = new CommandAgent({ command: 'node mycli.js' });
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    const result = await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toContain('base64 -d > /tmp/.prompt.md');
+    expect(commands[1]).toContain("cd '/workspace'");
+    expect(commands[1]).toContain('cat /tmp/.prompt.md | node mycli.js');
+    expect(result).toContain('output');
+  });
+
+  it('escapes single quotes in the workspace path', async () => {
+    const agent = new CommandAgent({ command: 'run' });
+    let executedCommand = '';
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      executedCommand = cmd;
+      return { stdout: 'ok', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('test', "/work's/place", mockRunCommand);
+
+    expect(executedCommand).toContain(`cd '/work'\\''s/place'`);
+  });
+
+  it('combines stdout and stderr and tolerates a non-zero exit', async () => {
+    const agent = new CommandAgent({ command: 'run' });
+    const mockRunCommand = vi.fn()
+      .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: 'partial', stderr: 'error', exitCode: 1 });
+
+    const result = await agent.run('test', '/workspace', mockRunCommand);
+    expect(result).toContain('partial');
+    expect(result).toContain('error');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -243,6 +243,43 @@ tasks:
     await expect(loadEvalConfig('/test')).rejects.toThrow('grader_provider must be one of');
   });
 
+  it('rejects the command agent when no command is set', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  agent: command
+tasks:
+  - name: test-task
+    instruction: do it
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    await expect(loadEvalConfig('/test')).rejects.toThrow('command');
+  });
+
+  it('accepts the command agent with a command in defaults', async () => {
+    mockPathExists.mockResolvedValue(true as any);
+    const yaml = `version: "1"
+defaults:
+  agent: command
+  command: "node mycli.js"
+tasks:
+  - name: test-task
+    instruction: do it
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`;
+    mockReadFile.mockResolvedValue(yaml as any);
+
+    const config = await loadEvalConfig('/test');
+    expect(config.defaults.agent).toBe('command');
+    expect(config.defaults.command).toBe('node mycli.js');
+  });
+
   it('rejects invalid provider on individual grader', async () => {
     mockPathExists.mockResolvedValue(true as any);
     const yaml = `version: "1"
@@ -529,5 +566,39 @@ describe('resolveTask', () => {
 
     const resolved = await resolveTask(task, defaults, '/base');
     expect(resolved.graders[0].setup).toBe('npm install -g typescript');
+  });
+
+  it('inherits the command from defaults for the command agent', async () => {
+    const commandDefaults: EvalDefaults = {
+      ...defaults,
+      agent: 'command',
+      command: 'node mycli.js',
+    };
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    const resolved = await resolveTask(task, commandDefaults, '/base');
+    expect(resolved.agent).toBe('command');
+    expect(resolved.command).toBe('node mycli.js');
+  });
+
+  it('lets a task override the command', async () => {
+    const commandDefaults: EvalDefaults = {
+      ...defaults,
+      agent: 'command',
+      command: 'node default.js',
+    };
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      command: 'node override.js',
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    const resolved = await resolveTask(task, commandDefaults, '/base');
+    expect(resolved.command).toBe('node override.js');
   });
 });


### PR DESCRIPTION
## Summary

Adds a `command` agent so users can point skillgrade at an **arbitrary command** — a custom script, a [deepagents](https://github.com/langchain-ai/deepagents) loop, or a small orchestrator over the Claude/OpenAI SDKs — without forking the package or implementing an ACP server.

```yaml
defaults:
  agent: command
  command: "node mycli.js"
```

Or via CLI: `skillgrade --agent=command --command="node mycli.js"`.

Implements the approach discussed in #25.

## Why it fits

- The agent contract already shells out via `runCommand`, so this is **purely additive** — no redesign, existing adapters untouched.
- Grading scores ground truth (deterministic graders / live workspace state), not the agent's stdout, so an arbitrary command slots in cleanly.
- The new agent is essentially the generic form of the existing `opencode` adapter.

## How it works

The task instruction is piped to the command's **stdin** (skillgrade writes it to `/tmp/.prompt.md` via base64, then runs `cat /tmp/.prompt.md | <command>` inside the workspace) — the same pattern the `gemini`/`codex` adapters already use. CLIs that take the prompt as an argument can wrap it in a one-line script that reads stdin.

No Docker auto-install for this agent: bring your own binary via `docker.setup`, or use `provider: local`.

## Changes

- **New:** `src/agents/command.ts` (`CommandAgent`)
- **Registry:** registered `command`, added `AgentConfig.command`
- **Config:** `command` field on defaults / per-task / resolved, with validation that a command is set when `agent: command`
- **CLI:** `--command` flag + help text
- **Docs:** README ("Custom Command Agent" section + options table), `eval.yaml` template, and the `skillgrade-setup` skill docs
- **Tests:** `CommandAgent` unit tests + config resolution/validation tests

## Verification

- `npm run build` — clean
- `npm test` — 171/171 passing