### PR TITLE
Split eval.yaml across files, add task metadata + filtering, and a reference output for graders

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,72 @@ instruction: instructions/fix-linting.md
 rubric: rubrics/workflow-quality.md
 ```
 
+### Reference output and metadata
+
+A task can carry the row's answer key and a set of labels:
+
+```yaml
+- name: easy--tooltip-token
+  instruction: |
+    Report the background colour token of the Tooltip's default variant.
+    Write {"token": "..."} to answer.json.
+  expected:                 # the answer key — graders only, never the agent
+    token: Brand/100
+    variants: [default, hover]
+  metadata:                 # labels for --filter, recorded with the results
+    tier: easy
+    form: open
+    tags: [smoke]
+  graders:
+    - type: deterministic
+      run: node graders/check-token.mjs
+```
+
+Both are optional: a task without `expected` is scored purely on what its
+graders measure, so golden-truth and metric-style tasks live in the same suite.
+
+skillgrade **delivers `expected`, it never interprets it** — comparison is the
+grader's job. A deterministic grader receives the task context as one JSON
+document in `SKILLGRADE_INPUT`, so `expected` keeps its structure:
+
+```js
+// graders/check-token.mjs — one script for every token task
+const { task, trial, expected, metadata } = JSON.parse(process.env.SKILLGRADE_INPUT);
+const answer = JSON.parse(fs.readFileSync('answer.json', 'utf8'));   // cwd is the workspace
+
+console.log(JSON.stringify({
+  score: answer.token === expected.token ? 1 : 0,
+  details: `${task}: want ${expected.token}, got ${answer.token ?? '(none)'}`,
+}));
+```
+
+```bash
+# or from a shell grader
+want=$(jq -r .expected.token <<< "$SKILLGRADE_INPUT")
+```
+
+An `llm_rubric` grader gets `expected` as an `## Expected Output` section in its
+prompt. Both channels are built after the agent process has exited, and neither
+writes to the workspace — unlike `run:` and `rubric:`, which are staged into the
+agent's working directory before it starts, so keep answer keys out of those.
+
+### Selecting which tasks to run
+
+`metadata` is what `--filter` selects on. Values are OR within a key and AND
+across keys; `--filter` and `--not-filter` are repeatable:
+
+```bash
+skillgrade --filter=tier=easy,medium              # easy OR medium
+skillgrade --filter=tier=hard --filter=form=refuse    # hard AND refuse
+skillgrade --filter=tags=smoke --not-filter=tags=flaky
+skillgrade --filter-pattern='^easy--'             # regex over task names
+skillgrade --filter=tier=easy --list              # print the selection, run nothing
+```
+
+A filter on a key that no task declares is an error rather than a silent
+match-everything — `--filter=teir=easy` should not quietly run the whole suite.
+Filters work the same whether the tasks are inline or imported.
+
 ### Splitting eval.yaml across files
 
 Any section can live in another file. `$import` takes a file, a directory (every

--- a/README.md
+++ b/README.md
@@ -138,6 +138,37 @@ instruction: instructions/fix-linting.md
 rubric: rubrics/workflow-quality.md
 ```
 
+### Splitting eval.yaml across files
+
+Any section can live in another file. `$import` takes a file, a directory (every
+`.yaml`/`.yml` inside it, sorted), a glob, or a list of those:
+
+```yaml
+version: "1"
+
+defaults:
+  $import: shared/defaults.yaml   # merged in place — keys below win
+  trials: 3
+
+tasks:
+  - $import: evals/easy/*.yaml    # one task per file, or a file holding a list
+  - $import: evals/hard           # a whole directory
+    trials: 10                    # applied to every task it imports
+  - name: still-inline            # inline tasks keep working
+    instruction: ...
+    graders: [...]
+```
+
+Each imported file is a normal YAML document — a single task, a list of tasks, or
+an object for a section like `defaults`. Imported files may import further files;
+paths are relative to the file that contains the `$import`, and cycles are an error.
+
+A task keeps working when you move it into its own file: **its relative paths
+resolve against its own directory first, then the eval root.** So
+`evals/easy/one.yaml` can say `instruction: instruction.md` for the file next to it
+while still pointing `run: node graders/check.mjs` at the shared graders directory
+at the root.
+
 ## Graders
 
 ### Deterministic

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -257,6 +257,16 @@ export async function runEvals(dir: string, opts: RunOptions) {
 export async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string, tmpDir: string) {
     await fs.ensureDir(tmpDir);
 
+    // An imported task looks for its files next to its own file first
+    const baseDirs = resolved.baseDirs?.length ? resolved.baseDirs : [baseDir];
+    const findSrc = async (ref: string) => {
+        for (const dir of baseDirs) {
+            const candidate = path.resolve(dir, ref);
+            if (await fs.pathExists(candidate)) return candidate;
+        }
+        return null;
+    };
+
     // Write each deterministic grader script
     await fs.ensureDir(path.join(tmpDir, 'tests'));
     const detGraders = resolved.graders.filter(g => g.type === 'deterministic');
@@ -274,9 +284,9 @@ export async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string
             const pathMatches = g.run.match(/[\w./-]+\.\w{1,4}/g) || [];
             for (const ref of pathMatches) {
                 const refDir = ref.split('/')[0];
-                const srcDir = path.resolve(baseDir, refDir);
+                const srcDir = await findSrc(refDir);
                 const destDir = path.join(tmpDir, refDir);
-                if (refDir !== ref && await fs.pathExists(srcDir) && !await fs.pathExists(destDir)) {
+                if (refDir !== ref && srcDir && !await fs.pathExists(destDir)) {
                     await fs.copy(srcDir, destDir);
                 }
             }
@@ -326,8 +336,8 @@ export async function prepareTempTaskDir(resolved: ResolvedTask, baseDir: string
 
     // Copy workspace files
     for (const w of resolved.workspace) {
-        const srcPath = path.resolve(baseDir, w.src);
-        if (await fs.pathExists(srcPath)) {
+        const srcPath = await findSrc(w.src);
+        if (srcPath) {
             if (resolved.provider === 'local') {
                 // For local provider: copy directly to destination path in tmpDir
                 const destPath = path.join(tmpDir, w.dest);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
 import { loadEvalConfig, resolveTask } from '../core/config';
+import { TaskFilter, describeSelection, metadataKeys, selectTasks } from '../core/filter';
 import { detectSkills } from '../core/skills';
 import { DockerProvider } from '../providers/docker';
 import { LocalProvider } from '../providers/local';
@@ -19,6 +20,9 @@ import { fmt, header, kv, resultsSummary, validationResult } from '../utils/cli'
 
 interface RunOptions {
     eval?: string;       // run specific eval(s) by name (comma-separated)
+    filters?: TaskFilter[];   // --filter / --not-filter over task metadata
+    filterPattern?: string;   // --filter-pattern regex over task names
+    list?: boolean;           // print the selection and run nothing
     trials?: number;     // override trial count
     parallel?: number;
     validate?: boolean;
@@ -81,16 +85,41 @@ export async function runEvals(dir: string, opts: RunOptions) {
         }
     }
 
-    // Filter evals
-    let tasksToRun = config.tasks;
-    if (opts.eval) {
-        const evalNames = opts.eval.split(',').map(s => s.trim());
-        tasksToRun = config.tasks.filter(t => evalNames.includes(t.name));
-        if (tasksToRun.length === 0) {
-            console.error(`  ${fmt.red('error')}  eval "${opts.eval}" not found`);
+    // Select which of the tasks to run: by name, by name pattern, by metadata
+    let tasksToRun;
+    try {
+        tasksToRun = selectTasks(config.tasks, {
+            names: opts.eval?.split(',').map(s => s.trim()).filter(Boolean),
+            filters: opts.filters,
+            pattern: opts.filterPattern,
+        });
+    } catch (err) {
+        console.error(`  ${fmt.red('error')}  ${err instanceof Error ? err.message : err}`);
+        if (opts.eval) {
             console.log(`  ${fmt.dim('available:')} ${config.tasks.map(t => t.name).join(', ')}`);
-            throw new Error(`Eval "${opts.eval}" not found`);
         }
+        throw err;
+    }
+
+    const narrowed = tasksToRun.length !== config.tasks.length;
+    if (narrowed) {
+        kv('selected', `${tasksToRun.length} of ${config.tasks.length} tasks`);
+    }
+
+    if (opts.list) {
+        header(`tasks (${tasksToRun.length})`);
+        for (const line of describeSelection(tasksToRun)) {
+            console.log(`    ${line}`);
+        }
+        const keys = metadataKeys(config.tasks);
+        console.log(`\n  ${fmt.dim('metadata keys:')} ${keys.join(', ') || '(none)'}\n`);
+        return;
+    }
+
+    if (tasksToRun.length === 0) {
+        console.error(`  ${fmt.red('error')}  no tasks match the selection`);
+        console.log(`  ${fmt.dim('metadata keys:')} ${metadataKeys(config.tasks).join(', ') || '(none)'}`);
+        throw new Error('No tasks match the selection');
     }
 
     // Output directory
@@ -124,6 +153,8 @@ export async function runEvals(dir: string, opts: RunOptions) {
             timeoutSec: resolved.timeout,
             graderModel: resolved.grader_model,
             graderProvider: resolved.grader_provider,
+            expected: resolved.expected,
+            metadata: resolved.metadata,
             environment: resolved.environment,
         };
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -115,6 +115,10 @@ function validateConfig(raw: any): EvalConfig {
             throw new Error(`Task "${t.name}" uses the "command" agent but no command is set (add a "command" to the task or defaults)`);
         }
 
+        if (t.metadata !== undefined && (typeof t.metadata !== 'object' || t.metadata === null || Array.isArray(t.metadata))) {
+            throw new Error(`Task "${t.name}" has a "metadata" that is not an object — metadata holds key/value labels used by --filter`);
+        }
+
         const workspace: WorkspaceMapping[] = (t.workspace || []).map((w: any) => {
             if (typeof w === 'string') {
                 // Support shorthand: "fixtures/app.js" → same filename in workspace
@@ -145,6 +149,8 @@ function validateConfig(raw: any): EvalConfig {
                 };
             }),
             solution: t.solution,
+            expected: t.expected,
+            metadata: t.metadata,
             agent: t.agent,
             command: t.command,
             provider: t.provider,
@@ -228,6 +234,8 @@ export async function resolveTask(
         workspace: task.workspace || [],
         graders,
         solution,
+        expected: task.expected,
+        metadata: task.metadata,
         agent,
         command,
         provider,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,6 +13,7 @@ import {
     EnvironmentConfig,
     AcpConfig,
 } from './config.types';
+import { loadYamlWithImports, sourceFileOf } from './imports';
 
 // We use a simple YAML parser — js-yaml is the standard
 // For now, we'll use a lightweight approach: JSON-compatible YAML subset
@@ -41,16 +42,8 @@ export async function loadEvalConfig(dir: string): Promise<EvalConfig> {
         throw new Error(`No eval.yaml found in ${dir}`);
     }
 
-    // Dynamically import js-yaml
-    let yaml: any;
-    try {
-        yaml = require('js-yaml');
-    } catch {
-        throw new Error('js-yaml is required. Run: npm install js-yaml');
-    }
-
-    const content = await fs.readFile(yamlPath, 'utf-8');
-    const raw = yaml.load(content) as any;
+    // Sections may live in other files — expand every `$import` first
+    const raw = await loadYamlWithImports(yamlPath);
 
     return validateConfig(raw);
 }
@@ -161,6 +154,7 @@ function validateConfig(raw: any): EvalConfig {
             grader_provider: t.grader_provider,
             docker: t.docker,
             environment: t.environment,
+            sourceFile: sourceFileOf(t),
         };
     });
 
@@ -193,8 +187,15 @@ export async function resolveTask(
     const grader_provider = task.grader_provider || defaults.grader_provider;
     const acp = defaults.acp;  // ACP config is only at defaults level
 
+    // An imported task's relative paths belong to its own directory first,
+    // then fall back to the eval root so shared graders/fixtures keep working.
+    const baseDirs = [...new Set([
+        ...(task.sourceFile ? [path.dirname(task.sourceFile)] : []),
+        baseDir,
+    ])];
+
     // Resolve instruction — could be inline text or file path
-    const instruction = await resolveFileOrInline(task.instruction, baseDir);
+    const instruction = await resolveFileOrInline(task.instruction, baseDirs);
 
     // Resolve graders
     const graders: ResolvedGrader[] = await Promise.all(
@@ -207,10 +208,10 @@ export async function resolveTask(
                 weight: g.weight,
             };
             if (g.type === 'deterministic' && g.run) {
-                resolved.run = await resolveFileOrInline(g.run, baseDir);
+                resolved.run = await resolveFileOrInline(g.run, baseDirs);
             }
             if (g.type === 'llm_rubric' && g.rubric) {
-                resolved.rubric = await resolveFileOrInline(g.rubric, baseDir);
+                resolved.rubric = await resolveFileOrInline(g.rubric, baseDirs);
             }
             return resolved;
         })
@@ -218,7 +219,7 @@ export async function resolveTask(
 
     // Resolve solution path
     const solution = task.solution
-        ? path.resolve(baseDir, task.solution)
+        ? await resolveExistingPath(task.solution, baseDirs)
         : undefined;
 
     return {
@@ -237,6 +238,7 @@ export async function resolveTask(
         acp,
         docker,
         environment,
+        baseDirs,
     };
 }
 
@@ -244,17 +246,28 @@ export async function resolveTask(
  * If value looks like a file path and the file exists, read it.
  * Otherwise return the value as-is (inline content).
  */
-async function resolveFileOrInline(value: string, baseDir: string): Promise<string> {
+async function resolveFileOrInline(value: string, baseDirs: string[]): Promise<string> {
     const trimmed = value.trim();
 
     // Multi-line strings are always inline content
     if (trimmed.includes('\n')) return trimmed;
 
     // Check if it could be a file path (no spaces except in path, has extension)
-    const candidate = path.resolve(baseDir, trimmed);
-    if (await fs.pathExists(candidate)) {
-        return (await fs.readFile(candidate, 'utf-8')).trim();
+    for (const baseDir of baseDirs) {
+        const candidate = path.resolve(baseDir, trimmed);
+        if (await fs.pathExists(candidate)) {
+            return (await fs.readFile(candidate, 'utf-8')).trim();
+        }
     }
 
     return trimmed;
+}
+
+/** Resolve a relative path against the first base dir that contains it. */
+async function resolveExistingPath(value: string, baseDirs: string[]): Promise<string> {
+    for (const baseDir of baseDirs) {
+        const candidate = path.resolve(baseDir, value);
+        if (await fs.pathExists(candidate)) return candidate;
+    }
+    return path.resolve(baseDirs[baseDirs.length - 1], value);
 }

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -51,6 +51,20 @@ export interface EvalTaskConfig {
     graders: EvalGraderConfig[];
     solution?: string;      // path to reference solution script
 
+    /**
+     * Reference output for this task — the row's answer key. Reaches graders
+     * only (as `SKILLGRADE_INPUT` for deterministic, as a prompt section for
+     * llm_rubric) and is never written into the agent's workspace. skillgrade
+     * delivers it; it never interprets it.
+     */
+    expected?: unknown;
+
+    /**
+     * Labels used to select and slice tasks (`--filter tier=easy`). Never
+     * reaches the agent; recorded with the results.
+     */
+    metadata?: Record<string, unknown>;
+
     // Per-task overrides
     agent?: string;
     command?: string;   // command to run when agent is 'command'
@@ -96,6 +110,8 @@ export interface ResolvedTask {
     workspace: WorkspaceMapping[];
     graders: ResolvedGrader[];
     solution?: string;      // resolved file path
+    expected?: unknown;                     // reference output — graders only, never the workspace
+    metadata?: Record<string, unknown>;     // filterable labels — never sent to the agent
     agent: string;
     command?: string;       // command to run when agent is 'command'
     provider: string;

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -61,6 +61,9 @@ export interface EvalTaskConfig {
     grader_provider?: 'gemini' | 'anthropic' | 'openai';
     docker?: DockerConfig;
     environment?: Partial<EnvironmentConfig>;
+
+    /** Absolute path of the file this task was parsed from — set when the task came from a `$import`. */
+    sourceFile?: string;
 }
 
 /** Top-level defaults */
@@ -103,6 +106,8 @@ export interface ResolvedTask {
     acp?: AcpConfig;        // ACP agent configuration
     docker: DockerConfig;
     environment: EnvironmentConfig;
+    /** Directories that this task's relative paths resolve against, in order: its own file's dir, then the eval root. */
+    baseDirs?: string[];
 }
 
 export interface ResolvedGrader {

--- a/src/core/filter.ts
+++ b/src/core/filter.ts
@@ -1,0 +1,112 @@
+/**
+ * Task selection.
+ *
+ * Selecting a subset of a large suite: by name, by regex over names, or by the
+ * `metadata` labels a task carries. Works the same whether the tasks are inline
+ * in eval.yaml or imported from other files.
+ *
+ *   skillgrade --filter tier=easy,medium         # OR within one key
+ *   skillgrade --filter tier=hard --filter form=refuse   # AND across keys
+ *   skillgrade --filter tags=smoke --not-filter tags=flaky
+ *   skillgrade --filter-pattern '^easy--'        # regex over task names
+ *   skillgrade --list                            # print the selection, run nothing
+ *
+ * An unknown metadata key is an error rather than a match-everything, because
+ * `--filter teir=easy` silently running all 300 tasks is the expensive failure.
+ */
+import { EvalTaskConfig } from './config.types';
+
+export interface TaskFilter {
+    key: string;
+    values: string[];
+    negate: boolean;
+}
+
+export interface TaskSelection {
+    names?: string[];        // --eval=a,b (exact names)
+    filters?: TaskFilter[];  // --filter / --not-filter
+    pattern?: string;        // --filter-pattern (regex over names)
+}
+
+/** Parse `key=value` or `key=v1,v2` into a filter. */
+export function parseFilter(spec: string, negate: boolean): TaskFilter {
+    const eq = spec.indexOf('=');
+    if (eq <= 0) {
+        throw new Error(`Invalid filter "${spec}" — expected key=value (e.g. tier=easy)`);
+    }
+    const key = spec.slice(0, eq).trim();
+    const values = spec.slice(eq + 1).split(',').map(v => v.trim()).filter(Boolean);
+    if (values.length === 0) {
+        throw new Error(`Invalid filter "${spec}" — no value after "="`);
+    }
+    return { key, values, negate };
+}
+
+/** Every metadata key used anywhere in the suite, sorted. */
+export function metadataKeys(tasks: EvalTaskConfig[]): string[] {
+    const keys = new Set<string>();
+    for (const task of tasks) {
+        for (const key of Object.keys(task.metadata || {})) keys.add(key);
+    }
+    return [...keys].sort();
+}
+
+/** Does a task's metadata value match any of the filter's values? */
+function matches(task: EvalTaskConfig, filter: TaskFilter): boolean {
+    const value = task.metadata?.[filter.key];
+    if (value === undefined || value === null) return false;
+    const actual = (Array.isArray(value) ? value : [value]).map(v => String(v));
+    return filter.values.some(wanted => actual.includes(wanted));
+}
+
+/**
+ * Apply a selection to the task list. Filters AND together across keys and OR
+ * within a key; `--not-filter` excludes any task that matches.
+ */
+export function selectTasks(tasks: EvalTaskConfig[], selection: TaskSelection): EvalTaskConfig[] {
+    let selected = tasks;
+
+    if (selection.names?.length) {
+        const wanted = new Set(selection.names);
+        const unknown = selection.names.filter(n => !tasks.some(t => t.name === n));
+        if (unknown.length > 0) {
+            throw new Error(`Eval "${unknown.join(', ')}" not found`);
+        }
+        selected = selected.filter(t => wanted.has(t.name));
+    }
+
+    if (selection.pattern) {
+        let regex: RegExp;
+        try {
+            regex = new RegExp(selection.pattern);
+        } catch (err) {
+            throw new Error(`Invalid --filter-pattern "${selection.pattern}": ${err}`);
+        }
+        selected = selected.filter(t => regex.test(t.name));
+    }
+
+    if (selection.filters?.length) {
+        const known = new Set(metadataKeys(tasks));
+        for (const filter of selection.filters) {
+            if (!known.has(filter.key)) {
+                const available = [...known].join(', ') || '(no task declares metadata)';
+                throw new Error(`Unknown filter key "${filter.key}" — available metadata keys: ${available}`);
+            }
+        }
+        selected = selected.filter(task =>
+            selection.filters!.every(f => f.negate ? !matches(task, f) : matches(task, f))
+        );
+    }
+
+    return selected;
+}
+
+/** One line per task: its name and its metadata, for `--list`. */
+export function describeSelection(tasks: EvalTaskConfig[]): string[] {
+    return tasks.map(task => {
+        const labels = Object.entries(task.metadata || {})
+            .map(([k, v]) => `${k}=${Array.isArray(v) ? v.join('|') : String(v)}`)
+            .join(' ');
+        return labels ? `${task.name}  ${labels}` : task.name;
+    });
+}

--- a/src/core/imports.ts
+++ b/src/core/imports.ts
@@ -67,7 +67,7 @@ async function expand(node: any, file: string, stack: string[]): Promise<any> {
         const out: any[] = [];
         for (const item of node) {
             if (isImportNode(item)) {
-                out.push(...await expandImport(item, file, stack));
+                out.push(...(await expandImport(item, file, stack)).items);
             } else {
                 out.push(await expand(item, file, stack));
             }
@@ -78,12 +78,11 @@ async function expand(node: any, file: string, stack: string[]): Promise<any> {
     if (!isPlainObject(node)) return node;
 
     if (isImportNode(node)) {
-        const imported = await expandImport(node, file, stack);
-        // A single imported object stays an object; anything else (a file
-        // holding a list, or several matched files) becomes an array.
-        return imported.length === 1 && !Array.isArray(imported[0]) && isPlainObject(imported[0])
-            ? imported[0]
-            : imported;
+        const { items, collapsible } = await expandImport(node, file, stack);
+        // One imported document that is itself an object stays an object (a
+        // section like `defaults`). A document holding a list, or several
+        // matched files, stays a list even when it has a single entry.
+        return collapsible ? items[0] : items;
     }
 
     const out: Record<string, any> = {};
@@ -98,11 +97,17 @@ async function expand(node: any, file: string, stack: string[]): Promise<any> {
  * Sibling keys are shallow-merged over every imported object, which gives
  * per-group overrides: `- {$import: evals/hard, trials: 10}`.
  */
-async function expandImport(node: Record<string, any>, file: string, stack: string[]): Promise<any[]> {
+async function expandImport(
+    node: Record<string, any>,
+    file: string,
+    stack: string[]
+): Promise<{ items: any[]; collapsible: boolean }> {
     const { [IMPORT_KEY]: spec, ...overrides } = node;
     const specs = Array.isArray(spec) ? spec : [spec];
 
     const items: any[] = [];
+    let documents = 0;
+    let sawList = false;
     for (const one of specs) {
         if (typeof one !== 'string') {
             throw new Error(`$import expects a path or a list of paths (in ${path.basename(file)})`);
@@ -113,14 +118,18 @@ async function expandImport(node: Record<string, any>, file: string, stack: stri
         }
         for (const target of targets) {
             const doc = await loadFile(target, stack);
+            documents++;
+            sawList ||= Array.isArray(doc);
             items.push(...(Array.isArray(doc) ? doc : [doc]));
         }
     }
 
-    if (Object.keys(overrides).length === 0) return items;
+    const collapsible = documents === 1 && !sawList && isPlainObject(items[0]);
+
+    if (Object.keys(overrides).length === 0) return { items, collapsible };
 
     const expandedOverrides = await expand(overrides, file, stack);
-    return items.map(item => {
+    const merged = items.map(item => {
         if (!isPlainObject(item)) {
             throw new Error(`$import "${specs.join(', ')}" returned a non-object, so the extra keys in ${path.basename(file)} have nothing to override`);
         }
@@ -128,6 +137,8 @@ async function expandImport(node: Record<string, any>, file: string, stack: stri
         // relative paths — spread drops the hidden tag, so re-apply it.
         return tag({ ...item, ...expandedOverrides }, sourceFileOf(item) ?? file);
     });
+
+    return { items: merged, collapsible };
 }
 
 /** Resolve one import spec (a file, a directory, or a glob) to YAML file paths. */

--- a/src/core/imports.ts
+++ b/src/core/imports.ts
@@ -1,0 +1,196 @@
+/**
+ * `$import` support for eval.yaml.
+ *
+ * Any section of an eval.yaml can live in another file:
+ *
+ *   defaults:
+ *     $import: shared/defaults.yaml   # object position → merged, siblings win
+ *   tasks:
+ *     - $import: evals/easy/*.yaml    # array position → spliced in
+ *     - $import: evals/hard           # a directory → every .yaml inside, sorted
+ *     - name: inline-still-works
+ *       ...
+ *
+ * Imported paths are relative to the file that contains the `$import`, and
+ * imported files may import further files. Every object keeps a hidden
+ * reference to the file it came from (see `sourceFileOf`) so that relative
+ * paths inside an imported task can resolve against that task's own directory.
+ */
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+const IMPORT_KEY = '$import';
+const SOURCE_KEY = '__sourceFile';
+const MAX_DEPTH = 32;
+const YAML_EXTS = ['.yaml', '.yml'];
+const SKIP_DIRS = new Set(['node_modules', '.git']);
+
+/** Absolute path of the file an object was parsed from, if known. */
+export function sourceFileOf(node: unknown): string | undefined {
+    if (!node || typeof node !== 'object') return undefined;
+    const value = (node as Record<string, unknown>)[SOURCE_KEY];
+    return typeof value === 'string' ? value : undefined;
+}
+
+/** Load a YAML file and expand every `$import` it (transitively) contains. */
+export async function loadYamlWithImports(file: string): Promise<any> {
+    return loadFile(path.resolve(file), []);
+}
+
+async function loadFile(absPath: string, stack: string[]): Promise<any> {
+    if (stack.includes(absPath)) {
+        const chain = [...stack, absPath].map(f => path.basename(f)).join(' → ');
+        throw new Error(`Circular $import: ${chain}`);
+    }
+    if (stack.length >= MAX_DEPTH) {
+        throw new Error(`$import nested more than ${MAX_DEPTH} levels deep (${absPath})`);
+    }
+    if (!await fs.pathExists(absPath)) {
+        throw new Error(`$import target not found: ${absPath}`);
+    }
+
+    const yaml = loadYamlModule();
+    const raw = yaml.load(await fs.readFile(absPath, 'utf-8'));
+    return expand(raw, absPath, [...stack, absPath]);
+}
+
+function loadYamlModule(): any {
+    try {
+        return require('js-yaml');
+    } catch {
+        throw new Error('js-yaml is required. Run: npm install js-yaml');
+    }
+}
+
+async function expand(node: any, file: string, stack: string[]): Promise<any> {
+    if (Array.isArray(node)) {
+        const out: any[] = [];
+        for (const item of node) {
+            if (isImportNode(item)) {
+                out.push(...await expandImport(item, file, stack));
+            } else {
+                out.push(await expand(item, file, stack));
+            }
+        }
+        return out;
+    }
+
+    if (!isPlainObject(node)) return node;
+
+    if (isImportNode(node)) {
+        const imported = await expandImport(node, file, stack);
+        // A single imported object stays an object; anything else (a file
+        // holding a list, or several matched files) becomes an array.
+        return imported.length === 1 && !Array.isArray(imported[0]) && isPlainObject(imported[0])
+            ? imported[0]
+            : imported;
+    }
+
+    const out: Record<string, any> = {};
+    for (const [key, value] of Object.entries(node)) {
+        out[key] = await expand(value, file, stack);
+    }
+    return tag(out, file);
+}
+
+/**
+ * Expand one `$import` node into the list of values it contributes.
+ * Sibling keys are shallow-merged over every imported object, which gives
+ * per-group overrides: `- {$import: evals/hard, trials: 10}`.
+ */
+async function expandImport(node: Record<string, any>, file: string, stack: string[]): Promise<any[]> {
+    const { [IMPORT_KEY]: spec, ...overrides } = node;
+    const specs = Array.isArray(spec) ? spec : [spec];
+
+    const items: any[] = [];
+    for (const one of specs) {
+        if (typeof one !== 'string') {
+            throw new Error(`$import expects a path or a list of paths (in ${path.basename(file)})`);
+        }
+        const targets = await resolveTargets(one, path.dirname(file));
+        if (targets.length === 0) {
+            throw new Error(`$import matched no files: "${one}" (in ${path.basename(file)})`);
+        }
+        for (const target of targets) {
+            const doc = await loadFile(target, stack);
+            items.push(...(Array.isArray(doc) ? doc : [doc]));
+        }
+    }
+
+    if (Object.keys(overrides).length === 0) return items;
+
+    const expandedOverrides = await expand(overrides, file, stack);
+    return items.map(item => {
+        if (!isPlainObject(item)) {
+            throw new Error(`$import "${specs.join(', ')}" returned a non-object, so the extra keys in ${path.basename(file)} have nothing to override`);
+        }
+        // The imported file, not the importing one, owns the merged object's
+        // relative paths — spread drops the hidden tag, so re-apply it.
+        return tag({ ...item, ...expandedOverrides }, sourceFileOf(item) ?? file);
+    });
+}
+
+/** Resolve one import spec (a file, a directory, or a glob) to YAML file paths. */
+async function resolveTargets(spec: string, baseDir: string): Promise<string[]> {
+    if (!spec.includes('*')) {
+        const candidate = path.resolve(baseDir, spec);
+        const stat = await fs.stat(candidate).catch(() => null);
+        if (stat?.isDirectory()) return collectYamlFiles(candidate);
+        return [candidate];   // missing files are reported by loadFile
+    }
+
+    const segments = spec.split('/').filter(s => s !== '' && s !== '.');
+    const firstMagic = segments.findIndex(s => s.includes('*'));
+    const root = path.resolve(baseDir, ...segments.slice(0, firstMagic));
+    const pattern = toRegExp(segments.slice(firstMagic));
+
+    const files = await collectFiles(root);
+    return files
+        .filter(f => pattern.test(path.relative(root, f).split(path.sep).join('/')))
+        .sort();
+}
+
+function toRegExp(segments: string[]): RegExp {
+    const source = segments.map((segment, i) => {
+        const last = i === segments.length - 1;
+        if (segment === '**') return last ? '.*' : '(?:[^/]+/)*';
+        const escaped = segment.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*');
+        return last ? escaped : `${escaped}/`;
+    }).join('');
+    return new RegExp(`^${source}$`);
+}
+
+async function collectYamlFiles(dir: string): Promise<string[]> {
+    const files = await collectFiles(dir);
+    return files.filter(f => YAML_EXTS.includes(path.extname(f))).sort();
+}
+
+async function collectFiles(dir: string, depth = 0): Promise<string[]> {
+    if (depth > MAX_DEPTH) return [];
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+    const out: string[] = [];
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (SKIP_DIRS.has(entry.name)) continue;
+            out.push(...await collectFiles(full, depth + 1));
+        } else if (entry.isFile()) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+function isImportNode(node: unknown): node is Record<string, any> {
+    return isPlainObject(node) && IMPORT_KEY in node;
+}
+
+function isPlainObject(node: unknown): node is Record<string, any> {
+    return !!node && typeof node === 'object' && !Array.isArray(node);
+}
+
+/** Record the source file without making it a visible (or serialized) key. */
+function tag<T extends object>(node: T, file: string): T {
+    Object.defineProperty(node, SOURCE_KEY, { value: file, enumerable: false, configurable: true });
+    return node;
+}

--- a/src/evalRunner.ts
+++ b/src/evalRunner.ts
@@ -67,6 +67,8 @@ export interface EvalRunOptions {
     graderModel?: string;       // default LLM grader model
     graderProvider?: 'gemini' | 'anthropic' | 'openai';  // default LLM grader provider
     graderTimeoutSec?: number;  // timeout per grader (default: 120s)
+    expected?: unknown;                     // reference output handed to graders
+    metadata?: Record<string, unknown>;     // task labels handed to graders and recorded with results
     environment: {
         cpus: number;
         memory_mb: number;
@@ -132,6 +134,7 @@ export class EvalRunner {
 
         const report: EvalReport = {
             task: taskName,
+            metadata: opts.metadata,
             pass_rate: totalReward / numTrials,
             pass_at_k: calculatePassAtK(numTrials, successes, numTrials),
             pass_pow_k: calculatePassPowK(numTrials, successes, numTrials),
@@ -247,6 +250,14 @@ export class EvalRunner {
                     model: graderDef.model || opts.graderModel,
                     provider: graderDef.provider || opts.graderProvider,
                     weight: graderDef.weight,
+                    // Assembled here, after the agent has exited — so the
+                    // reference answer cannot reach the agent.
+                    input: {
+                        task: path.basename(taskPath),
+                        trial: index,
+                        expected: opts.expected,
+                        metadata: opts.metadata,
+                    },
                 };
 
                 const graderTimeoutMs = (opts.graderTimeoutSec ?? 120) * 1000;

--- a/src/graders/index.ts
+++ b/src/graders/index.ts
@@ -34,7 +34,14 @@ export class DeterministicGrader implements Grader {
         env?: Record<string, string>
     ): Promise<GraderResult> {
         const command = config.command || 'bash tests/test.sh';
-        const result = await provider.runCommand(workspace, command, env);
+
+        // Hand the grader its task context as one JSON document. One variable
+        // rather than one per field, so `expected` keeps its structure.
+        const graderEnv = config.input
+            ? { ...env, SKILLGRADE_INPUT: JSON.stringify(config.input) }
+            : env;
+
+        const result = await provider.runCommand(workspace, command, graderEnv);
 
         // Parse JSON from stdout
         const jsonMatch = result.stdout.match(/\{[\s\S]*\}/);
@@ -148,12 +155,22 @@ export class LLMGrader implements Grader {
 
         const transcript = sections.join('\n\n');
 
+        // The reference output, when the task has one. Built into the prompt in
+        // memory — never written next to the rubric, which lands in the workspace.
+        const expectedSection = config.input?.expected !== undefined
+            ? `\n\n## Expected Output\nThe reference answer for this task. The agent never saw it.\n\n${
+                typeof config.input.expected === 'string'
+                    ? config.input.expected
+                    : JSON.stringify(config.input.expected, null, 2)
+            }`
+            : '';
+
         const prompt = `You are an evaluation judge. Score the following agent session on a scale from 0.0 to 1.0 based on the rubric below.
 
 IMPORTANT CONTEXT: The agent runs inside a CLI wrapper (e.g., Gemini CLI). The agent's tool calls (file edits, shell commands) appear as text in the "Agent Output" section. This is a real execution trace, not hallucination — the "Commands Executed" section shows the CLI invocation and its captured output. The "Prior Grader Results" section shows objective automated test results that verify the actual filesystem state after the agent ran.
 
 ## Rubric
-${rubric}
+${rubric}${expectedSection}
 
 ## Session Transcript
 ${transcript}

--- a/src/skillgrade.ts
+++ b/src/skillgrade.ts
@@ -18,6 +18,7 @@
  *   --preview          Open results after running
  */
 
+import { parseFilter } from './core/filter';
 import { runInit } from './commands/init';
 import { runEvals } from './commands/run';
 import { runPreview } from './commands/preview';
@@ -30,8 +31,12 @@ async function main() {
     const command = args[0];
     const cwd = process.cwd();
 
-    // Parse global flags
-    const getFlag = (name: string) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
+    // Parse global flags. Values may contain "=" (regexes, filter values), so
+    // take everything after the first one; repeatable flags collect every match.
+    const getFlags = (name: string) => args
+        .filter(a => a.startsWith(`--${name}=`))
+        .map(a => a.slice(`--${name}=`.length));
+    const getFlag = (name: string) => getFlags(name)[0];
     const hasFlag = (name: string) => args.includes(`--${name}`);
 
     if (command === '--help' || command === '-h') {
@@ -90,8 +95,16 @@ async function main() {
 
     const outputDir = getFlag('output') || path.join(os.tmpdir(), 'skillgrade');
 
+    const filters = [
+        ...getFlags('filter').map(spec => parseFilter(spec, false)),
+        ...getFlags('not-filter').map(spec => parseFilter(spec, true)),
+    ];
+
     await runEvals(cwd, {
         eval: evalFilter,
+        filters,
+        filterPattern: getFlag('filter-pattern'),
+        list: hasFlag('list'),
         trials: explicitTrials ?? presetTrials,
         parallel: getFlag('parallel') ? parseInt(getFlag('parallel')!) : undefined,
         validate: hasFlag('validate'),
@@ -128,8 +141,15 @@ function printHelp() {
     --reliable         Reliable pass rate (15 trials, reports mean reward)
     --regression       High-confidence regression (30 trials, reports pass^k)
 
-  Options:
+  Selecting tasks:
     --eval=NAME[,NAME] Run specific evals by name (comma-separated)
+    --filter=KEY=VAL   Keep tasks whose metadata matches (repeatable).
+                       Comma-separated values are OR; repeated flags are AND.
+    --not-filter=KEY=VAL   Drop tasks whose metadata matches (repeatable)
+    --filter-pattern=RE    Keep tasks whose name matches a regex
+    --list             Print the selected tasks and exit without running
+
+  Options:
     --grader=TYPE      Run only graders of this type (deterministic|llm_rubric)
     --trials=N         Override trial count (overrides preset)
     --parallel=N       Run trials concurrently
@@ -153,6 +173,10 @@ function printHelp() {
     skillgrade --smoke             # quick 5-trial smoke test
     skillgrade --eval=fix-linting  # run a specific eval
     skillgrade --eval=foo,bar      # run multiple evals
+    skillgrade --filter=tier=easy,medium           # by metadata, OR within a key
+    skillgrade --filter=tier=hard --filter=form=refuse   # AND across keys
+    skillgrade --filter=tags=smoke --not-filter=tags=flaky
+    skillgrade --filter-pattern='^easy--' --list   # preview a selection
     skillgrade --regression --ci   # CI regression with 30 trials
     skillgrade --agent=acp --acp-command="gemini --acp"  # use ACP-compatible agent
     skillgrade preview browser     # open web UI

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,20 @@ export interface GraderConfig {
     model?: string;                               // for llm_rubric: LLM model override
     provider?: 'gemini' | 'anthropic' | 'openai'; // for llm_rubric: which LLM API to call (default: 'gemini')
     weight: number;
+    input?: GraderInput;                          // task context handed to the grader at grade time
+}
+
+/**
+ * What a grader is told about the task it is scoring. Deterministic graders
+ * receive it as JSON in `SKILLGRADE_INPUT`; llm_rubric graders get `expected`
+ * as a prompt section. It is assembled after the agent has exited, so none of
+ * it can reach the agent.
+ */
+export interface GraderInput {
+    task: string;
+    trial: number;
+    expected?: unknown;
+    metadata?: Record<string, unknown>;
 }
 
 export interface GraderResult {
@@ -68,6 +82,7 @@ export interface AgentResult {
 
 export interface EvalReport {
     task: string;
+    metadata?: Record<string, unknown>;   // task labels, recorded so results can be sliced by column
     pass_rate: number;
     pass_at_k: number;        // probability of ≥1 success in k trials
     pass_pow_k: number;       // probability of all k trials succeeding

--- a/tests/config.imports.test.ts
+++ b/tests/config.imports.test.ts
@@ -53,6 +53,18 @@ tasks:
         expect(config.tasks.map(t => t.name)).toEqual(['a', 'b']);
     });
 
+    it('keeps a single-entry list a list when it is the whole section', async () => {
+        await write('datasets/tasks.yaml', `- ${task('only-one').replace(/\n/g, '\n  ')}
+`);
+        await write('eval.yaml', `version: "1"
+tasks:
+  $import: datasets/tasks.yaml
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.name)).toEqual(['only-one']);
+    });
+
     it('expands a glob in sorted order and keeps inline tasks', async () => {
         await write('evals/easy/b.yaml', task('easy--b'));
         await write('evals/easy/a.yaml', task('easy--a'));

--- a/tests/config.imports.test.ts
+++ b/tests/config.imports.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { loadEvalConfig, resolveTask } from '../src/core/config';
+
+let dir: string;
+
+async function write(rel: string, content: string) {
+    const full = path.join(dir, rel);
+    await fs.ensureDir(path.dirname(full));
+    await fs.writeFile(full, content);
+    return full;
+}
+
+const task = (name: string, extra = '') => `name: ${name}
+instruction: "do ${name}"
+graders:
+  - type: deterministic
+    run: "echo ok"
+${extra}`;
+
+beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'skillgrade-imports-'));
+});
+
+afterEach(async () => {
+    await fs.remove(dir);
+});
+
+describe('$import in tasks', () => {
+    it('splices a single-task file into the tasks array', async () => {
+        await write('evals/open-tooltip.yaml', task('open-tooltip'));
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/open-tooltip.yaml
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.name)).toEqual(['open-tooltip']);
+    });
+
+    it('splices a file holding a list of tasks', async () => {
+        await write('evals/easy.yaml', `- ${task('a').replace(/\n/g, '\n  ')}
+- ${task('b').replace(/\n/g, '\n  ')}
+`);
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/easy.yaml
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.name)).toEqual(['a', 'b']);
+    });
+
+    it('expands a glob in sorted order and keeps inline tasks', async () => {
+        await write('evals/easy/b.yaml', task('easy--b'));
+        await write('evals/easy/a.yaml', task('easy--a'));
+        await write('evals/hard/c.yaml', task('hard--c'));
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/easy/*.yaml
+  - $import: evals/**/c.yaml
+  - name: inline
+    instruction: "inline"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.name)).toEqual(['easy--a', 'easy--b', 'hard--c', 'inline']);
+    });
+
+    it('imports every yaml file in a directory', async () => {
+        await write('evals/a.yaml', task('a'));
+        await write('evals/b.yml', task('b'));
+        await write('evals/README.md', 'not a task');
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.name)).toEqual(['a', 'b']);
+    });
+
+    it('accepts a list of import paths and a bare $import for the whole section', async () => {
+        await write('evals/a.yaml', task('a'));
+        await write('evals/b.yaml', task('b'));
+        await write('eval.yaml', `version: "1"
+tasks:
+  $import:
+    - evals/a.yaml
+    - evals/b.yaml
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.name)).toEqual(['a', 'b']);
+    });
+
+    it('lets sibling keys override every imported task', async () => {
+        await write('evals/a.yaml', task('a'));
+        await write('evals/b.yaml', task('b', 'trials: 2\n'));
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/*.yaml
+    trials: 10
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.trials)).toEqual([10, 10]);
+    });
+
+    it('resolves nested imports relative to the importing file', async () => {
+        await write('evals/easy/one.yaml', task('one'));
+        await write('evals/index.yaml', `- $import: easy/one.yaml
+`);
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/index.yaml
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.tasks.map(t => t.name)).toEqual(['one']);
+    });
+
+    it('imports the defaults section as an object, siblings winning', async () => {
+        await write('shared/defaults.yaml', `agent: command
+command: "node ./harness/run.mjs"
+provider: local
+trials: 5
+`);
+        await write('eval.yaml', `version: "1"
+defaults:
+  $import: shared/defaults.yaml
+  trials: 1
+tasks:
+  - name: a
+    instruction: "a"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`);
+
+        const config = await loadEvalConfig(dir);
+        expect(config.defaults.agent).toBe('command');
+        expect(config.defaults.provider).toBe('local');
+        expect(config.defaults.trials).toBe(1);
+    });
+
+    it('errors on a missing target, an empty glob, and a cycle', async () => {
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/nope.yaml
+`);
+        await expect(loadEvalConfig(dir)).rejects.toThrow('$import target not found');
+
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/*.yaml
+`);
+        await expect(loadEvalConfig(dir)).rejects.toThrow('matched no files');
+
+        await write('evals/loop.yaml', `- $import: ../evals/loop.yaml
+`);
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/loop.yaml
+`);
+        await expect(loadEvalConfig(dir)).rejects.toThrow('Circular $import');
+    });
+
+    it('keeps validation errors pointing at the offending task', async () => {
+        await write('evals/broken.yaml', `name: broken
+instruction: "x"
+`);
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/broken.yaml
+`);
+        await expect(loadEvalConfig(dir)).rejects.toThrow('Task "broken" must have at least one grader');
+    });
+});
+
+describe('relative paths inside an imported task', () => {
+    it('resolves against the task file first, then the eval root', async () => {
+        await write('evals/easy/instruction.md', 'Open the page for Tooltips.');
+        await write('prompts/quality.md', 'Shared rubric.');
+        await write('evals/easy/one.yaml', `name: one
+instruction: instruction.md
+graders:
+  - type: deterministic
+    run: "echo ok"
+  - type: llm_rubric
+    rubric: prompts/quality.md
+`);
+        await write('eval.yaml', `version: "1"
+tasks:
+  - $import: evals/easy/one.yaml
+`);
+
+        const config = await loadEvalConfig(dir);
+        const resolved = await resolveTask(config.tasks[0], config.defaults, dir);
+
+        expect(resolved.instruction).toBe('Open the page for Tooltips.');
+        expect(resolved.graders[1].rubric).toBe('Shared rubric.');
+        expect(resolved.baseDirs).toEqual([path.join(dir, 'evals/easy'), dir]);
+    });
+
+    it('leaves inline tasks resolving against the eval root only', async () => {
+        await write('instruction.md', 'Root instruction.');
+        await write('eval.yaml', `version: "1"
+tasks:
+  - name: a
+    instruction: instruction.md
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`);
+
+        const config = await loadEvalConfig(dir);
+        const resolved = await resolveTask(config.tasks[0], config.defaults, dir);
+
+        expect(resolved.instruction).toBe('Root instruction.');
+        expect(resolved.baseDirs).toEqual([dir]);
+    });
+});

--- a/tests/filter.test.ts
+++ b/tests/filter.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { describeSelection, metadataKeys, parseFilter, selectTasks } from '../src/core/filter';
+import { EvalTaskConfig } from '../src/core/config.types';
+
+const task = (name: string, metadata?: Record<string, unknown>): EvalTaskConfig => ({
+    name,
+    instruction: `do ${name}`,
+    graders: [{ type: 'deterministic', run: 'echo ok', weight: 1 }],
+    metadata,
+});
+
+const tasks = [
+    task('easy--open-tooltip', { tier: 'easy', form: 'open', tags: ['smoke'] }),
+    task('easy--open-badge', { tier: 'easy', form: 'open', tags: ['smoke', 'flaky'] }),
+    task('hard--refuse-missing', { tier: 'hard', form: 'refuse', tags: ['smoke'] }),
+    task('hard--compare-variants', { tier: 'hard', form: 'compare' }),
+    task('no-metadata'),
+];
+
+const names = (selected: EvalTaskConfig[]) => selected.map(t => t.name);
+
+describe('parseFilter', () => {
+    it('parses a key and its values', () => {
+        expect(parseFilter('tier=easy', false)).toEqual({ key: 'tier', values: ['easy'], negate: false });
+        expect(parseFilter('tier=easy,medium', true)).toEqual({ key: 'tier', values: ['easy', 'medium'], negate: true });
+    });
+
+    it('keeps "=" inside the value', () => {
+        expect(parseFilter('query=a=b', false).values).toEqual(['a=b']);
+    });
+
+    it('rejects specs without key=value', () => {
+        expect(() => parseFilter('tier', false)).toThrow('expected key=value');
+        expect(() => parseFilter('=easy', false)).toThrow('expected key=value');
+        expect(() => parseFilter('tier=', false)).toThrow('no value after');
+    });
+});
+
+describe('selectTasks', () => {
+    it('returns everything when nothing is selected', () => {
+        expect(selectTasks(tasks, {})).toHaveLength(5);
+    });
+
+    it('ORs values within one key', () => {
+        const selected = selectTasks(tasks, { filters: [parseFilter('form=open,compare', false)] });
+        expect(names(selected)).toEqual(['easy--open-tooltip', 'easy--open-badge', 'hard--compare-variants']);
+    });
+
+    it('ANDs across keys', () => {
+        const selected = selectTasks(tasks, {
+            filters: [parseFilter('tier=hard', false), parseFilter('form=refuse', false)],
+        });
+        expect(names(selected)).toEqual(['hard--refuse-missing']);
+    });
+
+    it('matches a value inside a list', () => {
+        const selected = selectTasks(tasks, { filters: [parseFilter('tags=smoke', false)] });
+        expect(names(selected)).toHaveLength(3);
+    });
+
+    it('excludes with a negated filter', () => {
+        const selected = selectTasks(tasks, {
+            filters: [parseFilter('tags=smoke', false), parseFilter('tags=flaky', true)],
+        });
+        expect(names(selected)).toEqual(['easy--open-tooltip', 'hard--refuse-missing']);
+    });
+
+    it('treats a task without the key as not matching', () => {
+        const selected = selectTasks(tasks, { filters: [parseFilter('tier=easy,hard', false)] });
+        expect(names(selected)).not.toContain('no-metadata');
+    });
+
+    it('errors on an unknown key instead of matching everything', () => {
+        expect(() => selectTasks(tasks, { filters: [parseFilter('teir=easy', false)] }))
+            .toThrow('Unknown filter key "teir" — available metadata keys: form, tags, tier');
+    });
+
+    it('selects by name and by name pattern', () => {
+        expect(names(selectTasks(tasks, { names: ['no-metadata'] }))).toEqual(['no-metadata']);
+        expect(() => selectTasks(tasks, { names: ['nope'] })).toThrow('Eval "nope" not found');
+        expect(names(selectTasks(tasks, { pattern: '^easy--' }))).toHaveLength(2);
+        expect(() => selectTasks(tasks, { pattern: '^(' })).toThrow('Invalid --filter-pattern');
+    });
+
+    it('combines a pattern with metadata filters', () => {
+        const selected = selectTasks(tasks, {
+            pattern: '^hard--',
+            filters: [parseFilter('tags=smoke', false)],
+        });
+        expect(names(selected)).toEqual(['hard--refuse-missing']);
+    });
+
+    it('can select nothing', () => {
+        expect(selectTasks(tasks, { filters: [parseFilter('tier=nope', false)] })).toEqual([]);
+    });
+});
+
+describe('metadataKeys / describeSelection', () => {
+    it('lists every key used in the suite', () => {
+        expect(metadataKeys(tasks)).toEqual(['form', 'tags', 'tier']);
+        expect(metadataKeys([task('a')])).toEqual([]);
+    });
+
+    it('renders one line per task with its labels', () => {
+        expect(describeSelection([tasks[1], tasks[4]])).toEqual([
+            'easy--open-badge  tier=easy form=open tags=smoke|flaky',
+            'no-metadata',
+        ]);
+    });
+});

--- a/tests/task-context.test.ts
+++ b/tests/task-context.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fsExtra from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { loadEvalConfig, resolveTask } from '../src/core/config';
+import { DeterministicGrader } from '../src/graders/index';
+import { EnvironmentProvider, GraderConfig } from '../src/types';
+
+let dir: string;
+
+beforeEach(async () => {
+    dir = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'skillgrade-context-'));
+});
+
+afterEach(async () => {
+    await fsExtra.remove(dir);
+});
+
+async function writeEval(yaml: string) {
+    await fsExtra.writeFile(path.join(dir, 'eval.yaml'), yaml);
+}
+
+describe('expected and metadata on a task', () => {
+    const yaml = `version: "1"
+tasks:
+  - name: easy--tooltip-token
+    instruction: "report the token"
+    expected:
+      token: Brand/100
+      variants: [default, hover]
+    metadata:
+      tier: easy
+      tags: [smoke]
+    graders:
+      - type: deterministic
+        run: node graders/check-token.mjs
+`;
+
+    it('survives parsing and resolution with its structure intact', async () => {
+        await writeEval(yaml);
+        const config = await loadEvalConfig(dir);
+        const resolved = await resolveTask(config.tasks[0], config.defaults, dir);
+
+        expect(resolved.expected).toEqual({ token: 'Brand/100', variants: ['default', 'hover'] });
+        expect(resolved.metadata).toEqual({ tier: 'easy', tags: ['smoke'] });
+    });
+
+    it('arrives the same way when the task is imported from another file', async () => {
+        await fsExtra.ensureDir(path.join(dir, 'datasets'));
+        await fsExtra.writeFile(path.join(dir, 'datasets', 'tasks.yaml'), `- name: easy--tooltip-token
+  instruction: "report the token"
+  expected:
+    token: Brand/100
+    variants: [default, hover]
+  metadata:
+    tier: easy
+    tags: [smoke]
+  graders:
+    - type: deterministic
+      run: node graders/check-token.mjs
+`);
+        await writeEval(`version: "1"
+tasks:
+  $import: datasets/tasks.yaml
+`);
+
+        const config = await loadEvalConfig(dir);
+        const resolved = await resolveTask(config.tasks[0], config.defaults, dir);
+
+        expect(resolved.expected).toEqual({ token: 'Brand/100', variants: ['default', 'hover'] });
+        expect(resolved.metadata).toEqual({ tier: 'easy', tags: ['smoke'] });
+    });
+
+    it('rejects metadata that is not a key/value object', async () => {
+        await writeEval(`version: "1"
+tasks:
+  - name: a
+    instruction: "a"
+    metadata: [tier, easy]
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`);
+        await expect(loadEvalConfig(dir)).rejects.toThrow('has a "metadata" that is not an object');
+    });
+
+    it('leaves expected and metadata undefined when absent', async () => {
+        await writeEval(`version: "1"
+tasks:
+  - name: metric-only
+    instruction: "measure something"
+    graders:
+      - type: deterministic
+        run: "echo ok"
+`);
+        const config = await loadEvalConfig(dir);
+        const resolved = await resolveTask(config.tasks[0], config.defaults, dir);
+
+        expect(resolved.expected).toBeUndefined();
+        expect(resolved.metadata).toBeUndefined();
+    });
+});
+
+describe('SKILLGRADE_INPUT reaching a deterministic grader', () => {
+    const grader = new DeterministicGrader();
+
+    function captureProvider(): { provider: EnvironmentProvider; env: () => Record<string, string> } {
+        const runCommand = vi.fn().mockResolvedValue({ stdout: '{"score":1}', stderr: '', exitCode: 0 });
+        return {
+            provider: { setup: vi.fn(), cleanup: vi.fn(), runCommand } as unknown as EnvironmentProvider,
+            env: () => runCommand.mock.calls[0][2],
+        };
+    }
+
+    it('serialises the task context as one JSON document', async () => {
+        const { provider, env } = captureProvider();
+        const config: GraderConfig = {
+            type: 'deterministic',
+            weight: 1,
+            input: {
+                task: 'easy--tooltip-token',
+                trial: 2,
+                expected: { token: 'Brand/100', variants: ['default', 'hover'] },
+                metadata: { tier: 'easy' },
+            },
+        };
+
+        await grader.grade('/workspace', provider, config, '/task', [], { ANTHROPIC_API_KEY: 'sk-test' });
+
+        const parsed = JSON.parse(env().SKILLGRADE_INPUT);
+        expect(parsed).toEqual(config.input);
+        expect(parsed.expected.variants).toEqual(['default', 'hover']);   // structure, not stringified primitives
+        expect(env().ANTHROPIC_API_KEY).toBe('sk-test');                  // existing env still passed through
+    });
+
+    it('passes env untouched when the task has no context', async () => {
+        const { provider, env } = captureProvider();
+        await grader.grade('/workspace', provider, { type: 'deterministic', weight: 1 }, '/task', [], { FOO: 'bar' });
+
+        expect(env()).toEqual({ FOO: 'bar' });
+        expect(env().SKILLGRADE_INPUT).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Implements #30, reshaped around your suggestion to break `eval.yaml` into sections that can be imported from other files — that turned out to be a better answer than the JSONL escape hatch the issue proposed, and it settles the open question in the issue (flat columns vs a nested `metadata` object) by removing the only argument for flat: if tasks are YAML files, nesting is free, so there is no CSV shape to design around.

Three commits' worth of behaviour, no breaking changes — every existing `eval.yaml` parses and runs unchanged.

## 1. `$import` — any section from another file

```yaml
version: "1"

defaults:
  $import: shared/defaults.yaml   # merged in place — keys below it win
  trials: 3

tasks:
  - $import: evals/easy/*.yaml    # one task per file, or a file holding a list
  - $import: evals/hard           # a directory: every .yaml inside, sorted
    trials: 10                    # applied to every task it imports
  - name: still-inline            # inline tasks keep working
    instruction: ...
    graders: [...]
```

`$import` takes a file, a directory, a glob, or a list of those. In an array it splices; in object position it merges with sibling keys winning. Imported files may import further files, paths resolve relative to the file holding the `$import`, and a cycle is an error naming the chain.

The part that makes splitting actually usable: **an imported task resolves its relative paths against its own directory first, then the eval root.** So `evals/easy/one.yaml` can say `instruction: instruction.md` for the file beside it while `run: node graders/check.mjs` still means the shared graders directory at the root. Without that, moving a task into a file breaks it or forces `../../` everywhere.

## 2. `expected` — a reference output for graders

```yaml
- name: easy--tooltip-token
  instruction: |
    Report the background colour token of the Tooltip's default variant.
    Write {"token": "..."} to answer.json.
  expected:
    token: Brand/100
    variants: [default, hover]
  metadata:
    tier: easy
    form: open
    tags: [smoke]
  graders:
    - type: deterministic
      run: node graders/check-token.mjs
```

skillgrade **delivers `expected` and never interprets it** — comparison stays the grader's job. Deterministic graders receive `{task, trial, expected, metadata}` as one JSON document in `SKILLGRADE_INPUT`; `llm_rubric` graders get `expected` as an `## Expected Output` prompt section:

```js
// graders/check-token.mjs — one script for every token task
const { task, trial, expected, metadata } = JSON.parse(process.env.SKILLGRADE_INPUT);
const answer = JSON.parse(fs.readFileSync('answer.json', 'utf8'));   // cwd is the workspace
console.log(JSON.stringify({
  score: answer.token === expected.token ? 1 : 0,
  details: `${task}: want ${expected.token}, got ${answer.token ?? '(none)'}`,
}));
```

One JSON variable rather than one variable per field, so nested objects and lists survive; a shell grader reads it with `jq -r .expected.token <<< "$SKILLGRADE_INPUT"`.

Why this is worth a schema field rather than left to users: the motivation is grader *reuse*. One `check-token.mjs` scores 300 generated rows that differ only in data, instead of 300 bespoke graders. The alternative available today is interpolating the answer into the `run:` line — but `run:` is written verbatim into `<workspace>/tests/test.sh` and the workspace is the agent's cwd, so that leaves the answer key beside the agent being graded (same for `rubric:` → `prompts/quality.md`). Both new channels are assembled *after* the agent process has exited and neither writes to the workspace, so the leak isn't reachable.

`expected` is optional. A task without one is scored purely on what its graders measure, so outcome-verified tasks and golden-truth rows live in the same suite and can even be mixed within one task (exact-match deterministic + rubric on the process, using the existing weights).

## 3. `metadata` and selection

`metadata` is nested rather than spread across top-level task keys: `validateConfig` allowlists task fields, so a stray top-level key is silently dropped today, and a flat namespace would collide with every field added to `EvalTaskConfig` later.

```bash
skillgrade --filter=tier=easy,medium                  # OR within a key
skillgrade --filter=tier=hard --filter=form=refuse    # AND across keys
skillgrade --filter=tags=smoke --not-filter=tags=flaky
skillgrade --filter-pattern='^easy--'                 # regex over names
skillgrade --filter=tier=easy --list                  # print the selection, run nothing
```

A filter on a key no task declares is a hard error listing the available keys — `--filter=teir=easy` quietly running the whole suite is the expensive failure. Selection happens after the config is loaded, so it behaves identically for inline and imported tasks, and reports now record the task's `metadata` next to the scores.

Flag parsing needed one fix for this: values now keep everything after the first `=` (the previous `split('=')[1]` truncates regexes and any value containing `=`), and repeatable flags collect every occurrence.

## Verification

- 235 tests pass (37 new: importer, filter engine, task-context delivery), `npm run build` clean.
- Ran end to end with `provider: local` over a three-row suite in one external dataset file. Two rows share `check-token.mjs` and score 1.00 / 0.50 purely from their differing `expected`; the third has no `expected` and its grader scores normally. Per-check details render the reference values, and the saved reports carry `metadata`.

## Notes

The first commit stands alone if you'd rather take `$import` on its own — the second couples `expected` and `--filter` because `metadata` exists in order to be filtered on. Happy to split, rename anything (`expected`, `SKILLGRADE_INPUT`, the flag names), or move the grader payload to stdin instead of an env var — stdin is the prettier contract (JSON in ↔ JSON out) but needs `AttachStdin` on the Docker exec and careful stream closing in `LocalProvider`, so I went with the channel that already reaches graders in both providers.

Not included, both cheap follow-ups if you want them: `--filter-sample` / `--filter-sample-per` (stratified sampling, "one of each kind"), and `--filter-failing <results-dir>`, which is now mostly a matter of reading the reports back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
