### PR TITLE
feat: model selection for the claude agent, and progress through the suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Reports are saved to `$TMPDIR/skillgrade/<skill-name>/results/`. Override with `
 | `--trials=N` | Override trial count |
 | `--parallel=N` | Run trials concurrently |
 | `--agent=gemini\|claude\|codex\|acp\|opencode\|command` | Override agent (default: auto-detect from API key) |
+| `--model=NAME` | Model the agent answers with (`claude`, `opencode`). Default: whatever the agent CLI is configured to use |
 | `--provider=docker\|local` | Override provider |
 | `--acp-command=CMD` | ACP agent command (e.g., `gemini --acp`) |
 | `--command=CMD` | Command to run for the `command` agent (e.g., `node mycli.js`) |
@@ -81,6 +82,7 @@ version: "1"
 
 defaults:
   agent: gemini          # gemini | claude | codex | acp | opencode | command
+  model: claude-opus-5   # model the agent answers with (claude, opencode)
   provider: docker       # docker | local
   trials: 5
   timeout: 300           # seconds
@@ -126,6 +128,7 @@ tasks:
 
     # Per-task overrides (optional)
     agent: claude
+    model: claude-sonnet-5       # override the model for this task only
     grader_provider: anthropic   # override default LLM grader provider
     trials: 10
     timeout: 600

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -1,6 +1,18 @@
 import { BaseAgent, CommandResult } from '../types';
 
+export interface ClaudeAgentConfig {
+    /** Model alias or full id, passed straight to `claude --model`. */
+    model?: string;
+}
+
 export class ClaudeAgent extends BaseAgent {
+    private config: ClaudeAgentConfig;
+
+    constructor(config: ClaudeAgentConfig = {}) {
+        super();
+        this.config = config;
+    }
+
     async run(
         instruction: string,
         _workspacePath: string,
@@ -10,7 +22,10 @@ export class ClaudeAgent extends BaseAgent {
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
-        const command = `claude -p --dangerously-skip-permissions "$(cat /tmp/.prompt.md)"`;
+        // Without --model, Claude Code answers with whatever the account default
+        // is — which is invisible in the results and can change under you.
+        const model = this.config.model ? ` --model ${shellQuote(this.config.model)}` : '';
+        const command = `claude -p --dangerously-skip-permissions${model} "$(cat /tmp/.prompt.md)"`;
         const result = await runCommand(command);
 
         if (result.exitCode !== 0) {
@@ -19,4 +34,8 @@ export class ClaudeAgent extends BaseAgent {
 
         return result.stdout + '\n' + result.stderr;
     }
+}
+
+function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -11,7 +11,7 @@
  */
 import { BaseAgent } from '../types';
 import { GeminiAgent } from './gemini';
-import { ClaudeAgent } from './claude';
+import { ClaudeAgent, ClaudeAgentConfig } from './claude';
 import { CodexAgent } from './codex';
 import { AcpAgent, AcpAgentConfig } from './acp';
 import { OpenCodeAgent, OpenCodeAgentConfig } from './opencode';
@@ -19,6 +19,8 @@ import { CommandAgent, CommandAgentConfig } from './command';
 
 /** Configuration for agent creation */
 export interface AgentConfig {
+    /** Claude-specific configuration */
+    claude?: ClaudeAgentConfig;
     /** ACP-specific configuration */
     acp?: AcpAgentConfig;
     /** OpenCode-specific configuration */
@@ -30,7 +32,7 @@ export interface AgentConfig {
 /** Registry of available agent implementations */
 const AGENT_REGISTRY: Record<string, (config?: AgentConfig) => BaseAgent> = {
     gemini: () => new GeminiAgent(),
-    claude: () => new ClaudeAgent(),
+    claude: (config) => new ClaudeAgent(config?.claude || {}),
     codex: () => new CodexAgent(),
     // ACP agent requires config, registered as placeholder
     acp: (config) => new AcpAgent(config?.acp || { command: 'gemini --acp' }),

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -15,7 +15,7 @@ import { createAgent, AgentConfig } from '../agents/registry';
 import { BaseAgent, EvalReport } from '../types';
 import { ResolvedTask } from '../core/config.types';
 import { parseEnvFile } from '../utils/env';
-import { fmt, header, kv, resultsSummary, validationResult } from '../utils/cli';
+import { fmt, header, kv, progress, resultsSummary, validationResult } from '../utils/cli';
 
 /** Agents that accept a model on the command line. */
 const MODEL_AWARE_AGENTS = new Set(['claude', 'opencode']);
@@ -113,7 +113,9 @@ export async function runEvals(dir: string, opts: RunOptions) {
     const warnedNoModelSupport = new Set<string>();
 
     // Run each task
+    let taskIndex = 0;
     for (const taskDef of tasksToRun) {
+        taskIndex++;
         const resolved = await resolveTask(taskDef, config.defaults, dir);
         const trials = opts.trials ?? resolved.trials;
         const parallel = opts.parallel ?? 1;
@@ -228,7 +230,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             // Normal eval mode
             const agent = createAgent(agentName, agentConfig);
 
-            header(resolved.name);
+            header(`${resolved.name}  ${fmt.dim(`(${taskIndex}/${tasksToRun.length})`)}`);
             console.log(`    ${fmt.dim('agent')} ${agentName}${modelName ? `  ${fmt.dim('model')} ${modelName}` : ''}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
             console.log();
 
@@ -252,6 +254,12 @@ export async function runEvals(dir: string, opts: RunOptions) {
                 console.error(`\n  ${fmt.fail('error')}  evaluation failed: ${err}\n`);
                 allPassed = false;
             }
+        }
+
+        // How far through the selected tasks we are. Pointless for a single
+        // task, and the run is otherwise silent about it until the very end.
+        if (tasksToRun.length > 1) {
+            progress(taskIndex, tasksToRun.length);
         }
 
         // Cleanup temp dir

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -17,6 +17,9 @@ import { ResolvedTask } from '../core/config.types';
 import { parseEnvFile } from '../utils/env';
 import { fmt, header, kv, resultsSummary, validationResult } from '../utils/cli';
 
+/** Agents that accept a model on the command line. */
+const MODEL_AWARE_AGENTS = new Set(['claude', 'opencode']);
+
 interface RunOptions {
     eval?: string;       // run specific eval(s) by name (comma-separated)
     trials?: number;     // override trial count
@@ -26,6 +29,7 @@ interface RunOptions {
     threshold?: number;
     preset?: 'smoke' | 'reliable' | 'regression';
     agent?: string;      // override agent (gemini|claude|codex|acp|opencode|command)
+    model?: string;      // override the model the agent answers with (claude, opencode)
     provider?: string;   // override provider (docker|local)
     output?: string;     // output directory for reports and temp files
     grader?: string;     // filter graders by type (deterministic|llm_rubric)
@@ -105,6 +109,9 @@ export async function runEvals(dir: string, opts: RunOptions) {
     const reports: EvalReport[] = [];
     let allPassed = true;
 
+    // Agents whose CLI takes a model; the rest ignore --model and are told so.
+    const warnedNoModelSupport = new Set<string>();
+
     // Run each task
     for (const taskDef of tasksToRun) {
         const resolved = await resolveTask(taskDef, config.defaults, dir);
@@ -142,10 +149,21 @@ export async function runEvals(dir: string, opts: RunOptions) {
             }
         }
         const providerName = opts.provider || resolved.provider;
+        // CLI flag > task-level override > defaults; undefined means the agent CLI decides
+        const requestedModel = opts.model || resolved.model;
+        // Only reported when it is actually used — printing a model the agent
+        // ignores would make a run look like something it was not.
+        const modelName = MODEL_AWARE_AGENTS.has(agentName) ? requestedModel : undefined;
+        if (requestedModel && !modelName && !warnedNoModelSupport.has(agentName)) {
+            warnedNoModelSupport.add(agentName);
+            console.error(`  ${fmt.red('warning')}  --model is ignored by the "${agentName}" agent`);
+        }
 
         // Build agent config
         const agentConfig: AgentConfig = {};
-        if (agentName === 'acp') {
+        if (agentName === 'claude') {
+            if (modelName) agentConfig.claude = { model: modelName };
+        } else if (agentName === 'acp') {
             const acpCommand = opts.acpCommand || resolved.acp?.command;
             if (!acpCommand) {
                 throw new Error('ACP agent requires a command. Specify via --acp-command or acp.command in eval.yaml');
@@ -160,8 +178,10 @@ export async function runEvals(dir: string, opts: RunOptions) {
             if (opts.openCodeAgent) {
                 agentConfig.opencode.agent = opts.openCodeAgent;
             }
-            if (opts.openCodeModel) {
-                agentConfig.opencode.model = opts.openCodeModel;
+            // --opencode-model predates --model and stays the more specific one
+            const openCodeModel = opts.openCodeModel || modelName;
+            if (openCodeModel) {
+                agentConfig.opencode.model = openCodeModel;
             }
         } else if (agentName === 'command') {
             const command = opts.command || resolved.command;
@@ -209,7 +229,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             const agent = createAgent(agentName, agentConfig);
 
             header(resolved.name);
-            console.log(`    ${fmt.dim('agent')} ${agentName}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
+            console.log(`    ${fmt.dim('agent')} ${agentName}${modelName ? `  ${fmt.dim('model')} ${modelName}` : ''}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
             console.log();
 
             try {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -153,6 +153,7 @@ function validateConfig(raw: any): EvalConfig {
             }),
             solution: t.solution,
             agent: t.agent,
+            model: t.model,
             command: t.command,
             provider: t.provider,
             trials: t.trials,
@@ -177,6 +178,7 @@ export async function resolveTask(
 ): Promise<ResolvedTask> {
     // Merge defaults with task overrides
     const agent = task.agent || defaults.agent;
+    const model = task.model || defaults.model;
     const command = task.command || defaults.command;
     const provider = task.provider || defaults.provider;
     const trials = task.trials ?? defaults.trials;
@@ -228,6 +230,7 @@ export async function resolveTask(
         graders,
         solution,
         agent,
+        model,
         command,
         provider,
         trials,

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -53,6 +53,7 @@ export interface EvalTaskConfig {
 
     // Per-task overrides
     agent?: string;
+    model?: string;     // model the agent answers with (agents that support one)
     command?: string;   // command to run when agent is 'command'
     provider?: string;
     trials?: number;
@@ -66,6 +67,7 @@ export interface EvalTaskConfig {
 /** Top-level defaults */
 export interface EvalDefaults {
     agent: string;      // 'gemini' | 'claude' | 'codex' | 'acp' | 'opencode' | 'command'
+    model?: string;     // model the agent answers with (agents that support one)
     command?: string;   // command to run when agent is 'command' (e.g. "node mycli.js")
     provider: string;   // 'docker' | 'local'
     trials: number;
@@ -94,6 +96,7 @@ export interface ResolvedTask {
     graders: ResolvedGrader[];
     solution?: string;      // resolved file path
     agent: string;
+    model?: string;         // model the agent answers with (agents that support one)
     command?: string;       // command to run when agent is 'command'
     provider: string;
     trials: number;

--- a/src/skillgrade.ts
+++ b/src/skillgrade.ts
@@ -99,6 +99,7 @@ async function main() {
         threshold: getFlag('threshold') ? parseFloat(getFlag('threshold')!) : undefined,
         preset,
         agent: getFlag('agent'),
+        model: getFlag('model'),
         provider: getFlag('provider'),
         grader: getFlag('grader'),
         output: outputDir,
@@ -134,6 +135,8 @@ function printHelp() {
     --trials=N         Override trial count (overrides preset)
     --parallel=N       Run trials concurrently
     --agent=gemini|claude|codex|acp|opencode|command   Override agent (default: auto-detect from API key)
+    --model=NAME       Model the agent answers with (claude, opencode).
+                       Default: whatever the agent CLI is configured to use.
     --provider=docker|local Override provider (default: docker)
     --acp-command=CMD  ACP agent command (e.g., "gemini --acp")
     --command=CMD      Command to run for the 'command' agent (e.g., "node mycli.js")
@@ -155,6 +158,7 @@ function printHelp() {
     skillgrade --eval=foo,bar      # run multiple evals
     skillgrade --regression --ci   # CI regression with 30 trials
     skillgrade --agent=acp --acp-command="gemini --acp"  # use ACP-compatible agent
+    skillgrade --agent=claude --model=opus         # compare models on one suite
     skillgrade preview browser     # open web UI
 `);
 }

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -54,6 +54,25 @@ export function trialRow(trialId: number, total: number, reward: number, duratio
     console.log(`${pad}  ${fmt.dim(trialLabel)} ${status}  ${fmt.bold(rewardStr)}  ${fmt.dim(duration.padEnd(7))} ${fmt.dim(commands + ' cmds')}  ${graderStr}`);
 }
 
+/**
+ * Render a fixed-width progress bar: `▓▓▓▓▓░░░░░  10/20  50%`.
+ *
+ * Segments are fixed rather than proportional to the terminal so the bar reads
+ * the same in a narrow pane, in CI logs and in a pasted transcript.
+ */
+export function progressBar(done: number, total: number, segments: number = 10): string {
+    const ratio = total > 0 ? Math.min(1, Math.max(0, done / total)) : 0;
+    const filled = Math.round(ratio * segments);
+    const bar = '▓'.repeat(filled) + '░'.repeat(Math.max(0, segments - filled));
+    const pct = `${Math.round(ratio * 100)}%`;
+    return `${bar}  ${done}/${total}  ${pct}`;
+}
+
+/** Print the progress line shown after each task completes */
+export function progress(done: number, total: number) {
+    console.log(`\n  ${fmt.dim('progress')}    ${progressBar(done, total)}`);
+}
+
 /** Print the results summary block */
 export function resultsSummary(passRate: number, passAtK: number, passPowK: number, trials: number, preset?: string) {
     const presetLabel = preset === 'smoke' ? ' (smoke test)'

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -87,6 +87,47 @@ describe('ClaudeAgent', () => {
     expect(result).toContain('output');
   });
 
+  it('omits --model when no model is configured', async () => {
+    const agent = new ClaudeAgent();
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).not.toContain('--model');
+  });
+
+  it('passes the configured model to the claude CLI', async () => {
+    const agent = new ClaudeAgent({ model: 'claude-opus-5' });
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).toContain("--model 'claude-opus-5'");
+    // the prompt must stay the last argument
+    expect(commands[1].indexOf('--model')).toBeLessThan(commands[1].indexOf('/tmp/.prompt.md'));
+  });
+
+  it('quotes a model containing shell metacharacters', async () => {
+    const agent = new ClaudeAgent({ model: "evil'; rm -rf /" });
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).toContain("--model 'evil'\\''; rm -rf /'");
+  });
+
   it('returns combined stdout and stderr', async () => {
     const agent = new ClaudeAgent();
     const mockRunCommand = vi.fn()

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -399,6 +399,30 @@ describe('resolveTask', () => {
     expect(resolved.docker.base).toBe('node:20-slim');
   });
 
+  it('leaves model undefined when neither task nor defaults set one', async () => {
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    const resolved = await resolveTask(task, defaults, '/base');
+    expect(resolved.model).toBeUndefined();
+  });
+
+  it('inherits model from defaults and lets a task override it', async () => {
+    const defaultsWithModel: EvalDefaults = { ...defaults, model: 'claude-sonnet-5' };
+    const inherits: EvalTaskConfig = {
+      name: 'inherits',
+      instruction: 'multi\nline',
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+    const overrides: EvalTaskConfig = { ...inherits, name: 'overrides', model: 'claude-opus-5' };
+
+    expect((await resolveTask(inherits, defaultsWithModel, '/base')).model).toBe('claude-sonnet-5');
+    expect((await resolveTask(overrides, defaultsWithModel, '/base')).model).toBe('claude-opus-5');
+  });
+
   it('resolves grader_provider on the task level', async () => {
     const defaultsWitProvider: EvalDefaults = {
       ...defaults,

--- a/tests/utils.progress.test.ts
+++ b/tests/utils.progress.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { progressBar } from '../src/utils/cli';
+
+describe('progressBar', () => {
+  it('renders the example from the docs', () => {
+    expect(progressBar(10, 20)).toBe('▓▓▓▓▓░░░░░  10/20  50%');
+  });
+
+  it('is empty at the start and full at the end', () => {
+    expect(progressBar(0, 22)).toBe('░░░░░░░░░░  0/22  0%');
+    expect(progressBar(22, 22)).toBe('▓▓▓▓▓▓▓▓▓▓  22/22  100%');
+  });
+
+  it('always renders exactly `segments` cells', () => {
+    for (let done = 0; done <= 7; done++) {
+      const bar = progressBar(done, 7).split('  ')[0];
+      expect(bar).toHaveLength(10);
+    }
+  });
+
+  it('honours a custom segment count', () => {
+    expect(progressBar(1, 4, 4)).toBe('▓░░░  1/4  25%');
+  });
+
+  it('does not divide by zero when there are no tasks', () => {
+    expect(progressBar(0, 0)).toBe('░░░░░░░░░░  0/0  0%');
+  });
+
+  it('clamps rather than overflowing when done exceeds total', () => {
+    expect(progressBar(5, 3)).toBe('▓▓▓▓▓▓▓▓▓▓  5/3  100%');
+  });
+});


### PR DESCRIPTION
Two small things that came out of using skillgrade to compare models on the same skill.

## 1. `--model` for the claude agent

`ClaudeAgent` hardcoded `claude -p --dangerously-skip-permissions`, so a run answered with whatever the account default happened to be — invisible in the results, and free to change underneath a suite. Comparing models deliberately meant wrapping the CLI in an `ANTHROPIC_MODEL` export.

```bash
skillgrade --agent=claude --model=claude-opus-5
```

```yaml
defaults:
  model: claude-sonnet-5
tasks:
  - name: hard-one
    model: claude-opus-5      # per-task override
```

Same `CLI flag > task > defaults` precedence as `agent` and `provider`. opencode reads it too, with the existing `--opencode-model` still winning where both are given.

Agents whose CLI takes no model (gemini, codex, acp, command) warn once and are **not** reported as running one:

```
  warning  --model is ignored by the "command" agent
```

Printing a model that the agent ignored seemed worse than printing nothing — it would make a run look like something it was not.

The per-task header names the model when there is one:

```
── palette-30cb6365  (11/22) ──────────────────────────
    agent claude  model claude-opus-5  provider local  trials 1
```

## 2. Progress through the suite

A run over 20+ tasks prints a Results block per task and nothing about the run as a whole until it ends, so there is no way to tell whether you are two minutes or twenty from done.

```
  progress    ▓▓▓▓▓░░░░░  11/22  50%
```

Fixed 10 segments rather than terminal-width, so it reads the same in a narrow pane, in CI logs and in a pasted transcript. Skipped for single-task runs, where `1/1 100%` says nothing.

## Notes

- 212 tests pass; 6 new ones cover the model plumbing (including shell-quoting a model with metacharacters) and the bar's edge cases (0 tasks, done > total, custom segment counts).
- Two commits, one per feature — happy to split into separate PRs, drop either half, or change the bar's characters if `▓░` is not to taste.
- Verified end to end against a stub `claude` on `PATH`: `CLAUDE CLI GOT: -p --dangerously-skip-permissions --model claude-opus-5 …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)