### PR TITLE
feat(agents): let the agent choose a model (--model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Reports are saved to `$TMPDIR/skillgrade/<skill-name>/results/`. Override with `
 | `--trials=N` | Override trial count |
 | `--parallel=N` | Run trials concurrently |
 | `--agent=gemini\|claude\|codex\|acp\|opencode\|command` | Override agent (default: auto-detect from API key) |
-| `--model=NAME` | Model the agent answers with (`claude`, `opencode`). Default: whatever the agent CLI is configured to use |
+| `--model=NAME` | Model the agent answers with (`gemini`, `claude`, `codex`, `opencode`). Default: whatever the agent CLI is configured to use |
 | `--provider=docker\|local` | Override provider |
 | `--acp-command=CMD` | ACP agent command (e.g., `gemini --acp`) |
 | `--command=CMD` | Command to run for the `command` agent (e.g., `node mycli.js`) |
@@ -82,7 +82,7 @@ version: "1"
 
 defaults:
   agent: gemini          # gemini | claude | codex | acp | opencode | command
-  model: claude-opus-5   # model the agent answers with (claude, opencode)
+  model: claude-opus-5   # model the agent answers with (gemini, claude, codex, opencode)
   provider: docker       # docker | local
   trials: 5
   timeout: 300           # seconds

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Reports are saved to `$TMPDIR/skillgrade/<skill-name>/results/`. Override with `
 | `--trials=N` | Override trial count |
 | `--parallel=N` | Run trials concurrently |
 | `--agent=gemini\|claude\|codex\|acp\|opencode\|command` | Override agent (default: auto-detect from API key) |
+| `--model=NAME` | Model the agent answers with (`claude`, `opencode`). Default: whatever the agent CLI is configured to use |
 | `--provider=docker\|local` | Override provider |
 | `--acp-command=CMD` | ACP agent command (e.g., `gemini --acp`) |
 | `--command=CMD` | Command to run for the `command` agent (e.g., `node mycli.js`) |
@@ -81,6 +82,7 @@ version: "1"
 
 defaults:
   agent: gemini          # gemini | claude | codex | acp | opencode | command
+  model: claude-opus-5   # model the agent answers with (claude, opencode)
   provider: docker       # docker | local
   trials: 5
   timeout: 300           # seconds
@@ -126,6 +128,7 @@ tasks:
 
     # Per-task overrides (optional)
     agent: claude
+    model: claude-sonnet-5       # override the model for this task only
     grader_provider: anthropic   # override default LLM grader provider
     trials: 10
     timeout: 600

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -1,6 +1,18 @@
 import { BaseAgent, CommandResult } from '../types';
 
+export interface ClaudeAgentConfig {
+    /** Model alias or full id, passed straight to `claude --model`. */
+    model?: string;
+}
+
 export class ClaudeAgent extends BaseAgent {
+    private config: ClaudeAgentConfig;
+
+    constructor(config: ClaudeAgentConfig = {}) {
+        super();
+        this.config = config;
+    }
+
     async run(
         instruction: string,
         _workspacePath: string,
@@ -10,7 +22,10 @@ export class ClaudeAgent extends BaseAgent {
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
-        const command = `claude -p --dangerously-skip-permissions "$(cat /tmp/.prompt.md)"`;
+        // Without --model, Claude Code answers with whatever the account default
+        // is — which is invisible in the results and can change under you.
+        const model = this.config.model ? ` --model ${shellQuote(this.config.model)}` : '';
+        const command = `claude -p --dangerously-skip-permissions${model} "$(cat /tmp/.prompt.md)"`;
         const result = await runCommand(command);
 
         if (result.exitCode !== 0) {
@@ -19,4 +34,8 @@ export class ClaudeAgent extends BaseAgent {
 
         return result.stdout + '\n' + result.stderr;
     }
+}
+
+function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -1,4 +1,5 @@
 import { BaseAgent, CommandResult } from '../types';
+import { shellQuote } from '../utils/shell';
 
 export interface ClaudeAgentConfig {
     /** Model alias or full id, passed straight to `claude --model`. */
@@ -34,8 +35,4 @@ export class ClaudeAgent extends BaseAgent {
 
         return result.stdout + '\n' + result.stderr;
     }
-}
-
-function shellQuote(value: string): string {
-    return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -1,4 +1,5 @@
 import { BaseAgent, CommandResult, AgentResult, SkillTriggerInfo } from '../types';
+import { shellQuote } from '../utils/shell';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -86,7 +87,19 @@ function parseCodexJsonOutput(rawOutput: string): AgentResult {
     };
 }
 
+export interface CodexAgentConfig {
+    /** Model name, passed straight to `codex exec --model`. */
+    model?: string;
+}
+
 export class CodexAgent extends BaseAgent {
+    private config: CodexAgentConfig;
+
+    constructor(config: CodexAgentConfig = {}) {
+        super();
+        this.config = config;
+    }
+
     /**
      * Read API keys from ~/.codex/auth.json
      * Returns environment variables to inject for codex CLI
@@ -136,7 +149,8 @@ export class CodexAgent extends BaseAgent {
         // Use --json for structured JSONL output, --ephemeral to avoid writing session files
         // codex exec runs non-interactively; --full-auto enables sandboxed auto-execution
         // --skip-git-repo-check allows running in non-git temp directories
-        const command = `cat /tmp/.prompt.md | codex exec --full-auto --skip-git-repo-check --json --ephemeral`;
+        const model = this.config.model ? ` --model ${shellQuote(this.config.model)}` : '';
+        const command = `cat /tmp/.prompt.md | codex exec --full-auto --skip-git-repo-check --json --ephemeral${model}`;
         const result = await runCommand(command, Object.keys(envVars).length > 0 ? envVars : undefined);
 
         if (result.exitCode !== 0) {

--- a/src/agents/gemini.ts
+++ b/src/agents/gemini.ts
@@ -1,6 +1,19 @@
 import { BaseAgent, CommandResult } from '../types';
+import { shellQuote } from '../utils/shell';
+
+export interface GeminiAgentConfig {
+    /** Model name, passed straight to `gemini --model`. */
+    model?: string;
+}
 
 export class GeminiAgent extends BaseAgent {
+    private config: GeminiAgentConfig;
+
+    constructor(config: GeminiAgentConfig = {}) {
+        super();
+        this.config = config;
+    }
+
     async run(
         instruction: string,
         _workspacePath: string,
@@ -10,7 +23,8 @@ export class GeminiAgent extends BaseAgent {
         const b64 = Buffer.from(instruction).toString('base64');
         await runCommand(`echo '${b64}' | base64 -d > /tmp/.prompt.md`);
 
-        const command = `gemini -y --sandbox=none -p "$(cat /tmp/.prompt.md)"`;
+        const model = this.config.model ? ` --model ${shellQuote(this.config.model)}` : '';
+        const command = `gemini -y --sandbox=none${model} -p "$(cat /tmp/.prompt.md)"`;
         const result = await runCommand(command);
 
         if (result.exitCode !== 0) {

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -10,9 +10,9 @@
  *   - command: arbitrary user-provided command (bring your own agent)
  */
 import { BaseAgent } from '../types';
-import { GeminiAgent } from './gemini';
+import { GeminiAgent, GeminiAgentConfig } from './gemini';
 import { ClaudeAgent, ClaudeAgentConfig } from './claude';
-import { CodexAgent } from './codex';
+import { CodexAgent, CodexAgentConfig } from './codex';
 import { AcpAgent, AcpAgentConfig } from './acp';
 import { OpenCodeAgent, OpenCodeAgentConfig } from './opencode';
 import { CommandAgent, CommandAgentConfig } from './command';
@@ -21,6 +21,10 @@ import { CommandAgent, CommandAgentConfig } from './command';
 export interface AgentConfig {
     /** Claude-specific configuration */
     claude?: ClaudeAgentConfig;
+    /** Gemini-specific configuration */
+    gemini?: GeminiAgentConfig;
+    /** Codex-specific configuration */
+    codex?: CodexAgentConfig;
     /** ACP-specific configuration */
     acp?: AcpAgentConfig;
     /** OpenCode-specific configuration */
@@ -31,9 +35,9 @@ export interface AgentConfig {
 
 /** Registry of available agent implementations */
 const AGENT_REGISTRY: Record<string, (config?: AgentConfig) => BaseAgent> = {
-    gemini: () => new GeminiAgent(),
+    gemini: (config) => new GeminiAgent(config?.gemini || {}),
     claude: (config) => new ClaudeAgent(config?.claude || {}),
-    codex: () => new CodexAgent(),
+    codex: (config) => new CodexAgent(config?.codex || {}),
     // ACP agent requires config, registered as placeholder
     acp: (config) => new AcpAgent(config?.acp || { command: 'gemini --acp' }),
     opencode: (config) => new OpenCodeAgent(config?.opencode || {}),

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -11,7 +11,7 @@
  */
 import { BaseAgent } from '../types';
 import { GeminiAgent } from './gemini';
-import { ClaudeAgent } from './claude';
+import { ClaudeAgent, ClaudeAgentConfig } from './claude';
 import { CodexAgent } from './codex';
 import { AcpAgent, AcpAgentConfig } from './acp';
 import { OpenCodeAgent, OpenCodeAgentConfig } from './opencode';
@@ -19,6 +19,8 @@ import { CommandAgent, CommandAgentConfig } from './command';
 
 /** Configuration for agent creation */
 export interface AgentConfig {
+    /** Claude-specific configuration */
+    claude?: ClaudeAgentConfig;
     /** ACP-specific configuration */
     acp?: AcpAgentConfig;
     /** OpenCode-specific configuration */
@@ -30,7 +32,7 @@ export interface AgentConfig {
 /** Registry of available agent implementations */
 const AGENT_REGISTRY: Record<string, (config?: AgentConfig) => BaseAgent> = {
     gemini: () => new GeminiAgent(),
-    claude: () => new ClaudeAgent(),
+    claude: (config) => new ClaudeAgent(config?.claude || {}),
     codex: () => new CodexAgent(),
     // ACP agent requires config, registered as placeholder
     acp: (config) => new AcpAgent(config?.acp || { command: 'gemini --acp' }),

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -18,7 +18,7 @@ import { parseEnvFile } from '../utils/env';
 import { fmt, header, kv, resultsSummary, validationResult } from '../utils/cli';
 
 /** Agents that accept a model on the command line. */
-const MODEL_AWARE_AGENTS = new Set(['claude', 'opencode']);
+const MODEL_AWARE_AGENTS = new Set(['gemini', 'claude', 'codex', 'opencode']);
 
 interface RunOptions {
     eval?: string;       // run specific eval(s) by name (comma-separated)
@@ -29,7 +29,7 @@ interface RunOptions {
     threshold?: number;
     preset?: 'smoke' | 'reliable' | 'regression';
     agent?: string;      // override agent (gemini|claude|codex|acp|opencode|command)
-    model?: string;      // override the model the agent answers with (claude, opencode)
+    model?: string;      // override the model the agent answers with (gemini, claude, codex, opencode)
     provider?: string;   // override provider (docker|local)
     output?: string;     // output directory for reports and temp files
     grader?: string;     // filter graders by type (deterministic|llm_rubric)
@@ -163,6 +163,10 @@ export async function runEvals(dir: string, opts: RunOptions) {
         const agentConfig: AgentConfig = {};
         if (agentName === 'claude') {
             if (modelName) agentConfig.claude = { model: modelName };
+        } else if (agentName === 'gemini') {
+            if (modelName) agentConfig.gemini = { model: modelName };
+        } else if (agentName === 'codex') {
+            if (modelName) agentConfig.codex = { model: modelName };
         } else if (agentName === 'acp') {
             const acpCommand = opts.acpCommand || resolved.acp?.command;
             if (!acpCommand) {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -17,6 +17,9 @@ import { ResolvedTask } from '../core/config.types';
 import { parseEnvFile } from '../utils/env';
 import { fmt, header, kv, resultsSummary, validationResult } from '../utils/cli';
 
+/** Agents that accept a model on the command line. */
+const MODEL_AWARE_AGENTS = new Set(['claude', 'opencode']);
+
 interface RunOptions {
     eval?: string;       // run specific eval(s) by name (comma-separated)
     trials?: number;     // override trial count
@@ -26,6 +29,7 @@ interface RunOptions {
     threshold?: number;
     preset?: 'smoke' | 'reliable' | 'regression';
     agent?: string;      // override agent (gemini|claude|codex|acp|opencode|command)
+    model?: string;      // override the model the agent answers with (claude, opencode)
     provider?: string;   // override provider (docker|local)
     output?: string;     // output directory for reports and temp files
     grader?: string;     // filter graders by type (deterministic|llm_rubric)
@@ -105,6 +109,9 @@ export async function runEvals(dir: string, opts: RunOptions) {
     const reports: EvalReport[] = [];
     let allPassed = true;
 
+    // Agents whose CLI takes a model; the rest ignore --model and are told so.
+    const warnedNoModelSupport = new Set<string>();
+
     // Run each task
     for (const taskDef of tasksToRun) {
         const resolved = await resolveTask(taskDef, config.defaults, dir);
@@ -142,10 +149,21 @@ export async function runEvals(dir: string, opts: RunOptions) {
             }
         }
         const providerName = opts.provider || resolved.provider;
+        // CLI flag > task-level override > defaults; undefined means the agent CLI decides
+        const requestedModel = opts.model || resolved.model;
+        // Only reported when it is actually used — printing a model the agent
+        // ignores would make a run look like something it was not.
+        const modelName = MODEL_AWARE_AGENTS.has(agentName) ? requestedModel : undefined;
+        if (requestedModel && !modelName && !warnedNoModelSupport.has(agentName)) {
+            warnedNoModelSupport.add(agentName);
+            console.error(`  ${fmt.red('warning')}  --model is ignored by the "${agentName}" agent`);
+        }
 
         // Build agent config
         const agentConfig: AgentConfig = {};
-        if (agentName === 'acp') {
+        if (agentName === 'claude') {
+            if (modelName) agentConfig.claude = { model: modelName };
+        } else if (agentName === 'acp') {
             const acpCommand = opts.acpCommand || resolved.acp?.command;
             if (!acpCommand) {
                 throw new Error('ACP agent requires a command. Specify via --acp-command or acp.command in eval.yaml');
@@ -160,8 +178,10 @@ export async function runEvals(dir: string, opts: RunOptions) {
             if (opts.openCodeAgent) {
                 agentConfig.opencode.agent = opts.openCodeAgent;
             }
-            if (opts.openCodeModel) {
-                agentConfig.opencode.model = opts.openCodeModel;
+            // --opencode-model predates --model and stays the more specific one
+            const openCodeModel = opts.openCodeModel || modelName;
+            if (openCodeModel) {
+                agentConfig.opencode.model = openCodeModel;
             }
         } else if (agentName === 'command') {
             const command = opts.command || resolved.command;
@@ -209,7 +229,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             const agent = createAgent(agentName, agentConfig);
 
             header(resolved.name);
-            console.log(`    ${fmt.dim('agent')} ${agentName}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
+            console.log(`    ${fmt.dim('agent')} ${agentName}${modelName ? `  ${fmt.dim('model')} ${modelName}` : ''}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
             console.log();
 
             try {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -153,6 +153,7 @@ function validateConfig(raw: any): EvalConfig {
             }),
             solution: t.solution,
             agent: t.agent,
+            model: t.model,
             command: t.command,
             provider: t.provider,
             trials: t.trials,
@@ -177,6 +178,7 @@ export async function resolveTask(
 ): Promise<ResolvedTask> {
     // Merge defaults with task overrides
     const agent = task.agent || defaults.agent;
+    const model = task.model || defaults.model;
     const command = task.command || defaults.command;
     const provider = task.provider || defaults.provider;
     const trials = task.trials ?? defaults.trials;
@@ -228,6 +230,7 @@ export async function resolveTask(
         graders,
         solution,
         agent,
+        model,
         command,
         provider,
         trials,

--- a/src/core/config.types.ts
+++ b/src/core/config.types.ts
@@ -53,6 +53,7 @@ export interface EvalTaskConfig {
 
     // Per-task overrides
     agent?: string;
+    model?: string;     // model the agent answers with (agents that support one)
     command?: string;   // command to run when agent is 'command'
     provider?: string;
     trials?: number;
@@ -66,6 +67,7 @@ export interface EvalTaskConfig {
 /** Top-level defaults */
 export interface EvalDefaults {
     agent: string;      // 'gemini' | 'claude' | 'codex' | 'acp' | 'opencode' | 'command'
+    model?: string;     // model the agent answers with (agents that support one)
     command?: string;   // command to run when agent is 'command' (e.g. "node mycli.js")
     provider: string;   // 'docker' | 'local'
     trials: number;
@@ -94,6 +96,7 @@ export interface ResolvedTask {
     graders: ResolvedGrader[];
     solution?: string;      // resolved file path
     agent: string;
+    model?: string;         // model the agent answers with (agents that support one)
     command?: string;       // command to run when agent is 'command'
     provider: string;
     trials: number;

--- a/src/skillgrade.ts
+++ b/src/skillgrade.ts
@@ -135,7 +135,8 @@ function printHelp() {
     --trials=N         Override trial count (overrides preset)
     --parallel=N       Run trials concurrently
     --agent=gemini|claude|codex|acp|opencode|command   Override agent (default: auto-detect from API key)
-    --model=NAME       Model the agent answers with (claude, opencode).
+    --model=NAME       Model the agent answers with (gemini, claude, codex,
+                       opencode).
                        Default: whatever the agent CLI is configured to use.
     --provider=docker|local Override provider (default: docker)
     --acp-command=CMD  ACP agent command (e.g., "gemini --acp")

--- a/src/skillgrade.ts
+++ b/src/skillgrade.ts
@@ -99,6 +99,7 @@ async function main() {
         threshold: getFlag('threshold') ? parseFloat(getFlag('threshold')!) : undefined,
         preset,
         agent: getFlag('agent'),
+        model: getFlag('model'),
         provider: getFlag('provider'),
         grader: getFlag('grader'),
         output: outputDir,
@@ -134,6 +135,8 @@ function printHelp() {
     --trials=N         Override trial count (overrides preset)
     --parallel=N       Run trials concurrently
     --agent=gemini|claude|codex|acp|opencode|command   Override agent (default: auto-detect from API key)
+    --model=NAME       Model the agent answers with (claude, opencode).
+                       Default: whatever the agent CLI is configured to use.
     --provider=docker|local Override provider (default: docker)
     --acp-command=CMD  ACP agent command (e.g., "gemini --acp")
     --command=CMD      Command to run for the 'command' agent (e.g., "node mycli.js")
@@ -155,6 +158,7 @@ function printHelp() {
     skillgrade --eval=foo,bar      # run multiple evals
     skillgrade --regression --ci   # CI regression with 30 trials
     skillgrade --agent=acp --acp-command="gemini --acp"  # use ACP-compatible agent
+    skillgrade --agent=claude --model=opus         # compare models on one suite
     skillgrade preview browser     # open web UI
 `);
 }

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,0 +1,14 @@
+/**
+ * Shell helpers for building agent CLI invocations.
+ */
+
+/**
+ * Single-quote a value for a POSIX shell.
+ *
+ * Agent commands are assembled as strings and handed to `sh -c`, so any value
+ * that came from eval.yaml or a CLI flag has to be quoted before it lands in
+ * one.
+ */
+export function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -3,6 +3,7 @@ import { GeminiAgent } from '../src/agents/gemini';
 import { ClaudeAgent } from '../src/agents/claude';
 import { OpenCodeAgent } from '../src/agents/opencode';
 import { CommandAgent } from '../src/agents/command';
+import { CodexAgent } from '../src/agents/codex';
 import { CommandResult } from '../src/types';
 
 beforeEach(() => {
@@ -27,6 +28,34 @@ describe('GeminiAgent', () => {
     expect(commands[1]).toContain('-y');
     expect(commands[1]).toContain('--sandbox=none');
     expect(result).toContain('output');
+  });
+
+  it('omits --model when no model is configured', async () => {
+    const agent = new GeminiAgent();
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).not.toContain('--model');
+  });
+
+  it('passes the configured model to the gemini CLI', async () => {
+    const agent = new GeminiAgent({ model: 'gemini-3-flash-preview' });
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).toContain("--model 'gemini-3-flash-preview'");
+    // -p and the prompt must stay last
+    expect(commands[1].indexOf('--model')).toBeLessThan(commands[1].indexOf('-p'));
   });
 
   it('returns combined stdout and stderr', async () => {
@@ -215,6 +244,35 @@ describe('OpenCodeAgent', () => {
     const result = await agent.run('test', '/workspace', mockRunCommand);
     expect(result).toContain('success');
     expect(result).toContain('warning');
+  });
+});
+
+describe('CodexAgent', () => {
+  it('omits --model when no model is configured', async () => {
+    const agent = new CodexAgent();
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).toContain('codex exec');
+    expect(commands[1]).not.toContain('--model');
+  });
+
+  it('passes the configured model to the codex CLI', async () => {
+    const agent = new CodexAgent({ model: 'gpt-5.6-codex' });
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).toContain("--model 'gpt-5.6-codex'");
   });
 });
 

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -87,6 +87,47 @@ describe('ClaudeAgent', () => {
     expect(result).toContain('output');
   });
 
+  it('omits --model when no model is configured', async () => {
+    const agent = new ClaudeAgent();
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).not.toContain('--model');
+  });
+
+  it('passes the configured model to the claude CLI', async () => {
+    const agent = new ClaudeAgent({ model: 'claude-opus-5' });
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).toContain("--model 'claude-opus-5'");
+    // the prompt must stay the last argument
+    expect(commands[1].indexOf('--model')).toBeLessThan(commands[1].indexOf('/tmp/.prompt.md'));
+  });
+
+  it('quotes a model containing shell metacharacters', async () => {
+    const agent = new ClaudeAgent({ model: "evil'; rm -rf /" });
+    const commands: string[] = [];
+    const mockRunCommand = vi.fn().mockImplementation(async (cmd: string): Promise<CommandResult> => {
+      commands.push(cmd);
+      return { stdout: 'output', stderr: '', exitCode: 0 };
+    });
+
+    await agent.run('Test instruction', '/workspace', mockRunCommand);
+
+    expect(commands[1]).toContain("--model 'evil'\\''; rm -rf /'");
+  });
+
   it('returns combined stdout and stderr', async () => {
     const agent = new ClaudeAgent();
     const mockRunCommand = vi.fn()

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -399,6 +399,30 @@ describe('resolveTask', () => {
     expect(resolved.docker.base).toBe('node:20-slim');
   });
 
+  it('leaves model undefined when neither task nor defaults set one', async () => {
+    const task: EvalTaskConfig = {
+      name: 'test-task',
+      instruction: 'multi\nline',
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+
+    const resolved = await resolveTask(task, defaults, '/base');
+    expect(resolved.model).toBeUndefined();
+  });
+
+  it('inherits model from defaults and lets a task override it', async () => {
+    const defaultsWithModel: EvalDefaults = { ...defaults, model: 'claude-sonnet-5' };
+    const inherits: EvalTaskConfig = {
+      name: 'inherits',
+      instruction: 'multi\nline',
+      graders: [{ type: 'deterministic', run: 'echo ok', weight: 1.0 }],
+    };
+    const overrides: EvalTaskConfig = { ...inherits, name: 'overrides', model: 'claude-opus-5' };
+
+    expect((await resolveTask(inherits, defaultsWithModel, '/base')).model).toBe('claude-sonnet-5');
+    expect((await resolveTask(overrides, defaultsWithModel, '/base')).model).toBe('claude-opus-5');
+  });
+
   it('resolves grader_provider on the task level', async () => {
     const defaultsWitProvider: EvalDefaults = {
       ...defaults,


### PR DESCRIPTION
Agents hardcode their CLI invocation, so a run answers with whatever the agent's account default happens to be — invisible in the results, and free to change underneath a suite. Two runs a week apart are not necessarily comparable, and comparing models deliberately ("does opus beat sonnet on my skill?") means wrapping the CLI in an env-var export.

```bash
skillgrade --agent=claude --model=claude-opus-5
```

```yaml
defaults:
  model: claude-sonnet-5
tasks:
  - name: hard-one
    model: claude-opus-5      # per-task override
```

Same `CLI flag > task > defaults` precedence as `agent` and `provider`.

## Which agents take it

Every agent CLI skillgrade drives has a model flag, so all four read it:

| agent | flag |
|---|---|
| gemini | `-m, --model` |
| claude | `--model` |
| codex | `-m, --model` (on `codex exec`) |
| opencode | `-m, --model` |

`--opencode-model` still wins where both are given, so nothing about the existing flag changes.

`acp` and `command` have no model of their own — the sub-agent command decides for the former, and the latter is an arbitrary executable. They warn once and are **not** reported as running a model:

```
  warning  --model is ignored by the "command" agent
```

Printing a model the agent ignored seemed worse than printing nothing — it would make a run look like something it was not.

The per-task header names it when there is one:

```
── palette-30cb6365 ───────────────────────────────────
    agent claude  model claude-opus-5  provider local  trials 1
```

## Notes

- 210 tests pass. 9 new: flag present/absent per agent, argument ordering (the prompt stays last), shell-quoting a model containing metacharacters, and `model` inheritance/override through `resolveTask`.
- The POSIX single-quoting moved to `utils/shell.ts` rather than being copied a third time.
- Verified end to end against a stub `claude` on `PATH`: `CLAUDE CLI GOT: -p --dangerously-skip-permissions --model claude-opus-5 …`