### PR TITLE
feat(cli): show progress through the suite after each task

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -16,7 +16,7 @@ import { createAgent, AgentConfig } from '../agents/registry';
 import { BaseAgent, EvalReport } from '../types';
 import { ResolvedTask } from '../core/config.types';
 import { parseEnvFile } from '../utils/env';
-import { fmt, header, kv, resultsSummary, validationResult } from '../utils/cli';
+import { fmt, header, kv, progress, resultsSummary, validationResult } from '../utils/cli';
 
 /** Agents that accept a model on the command line. */
 const MODEL_AWARE_AGENTS = new Set(['gemini', 'claude', 'codex', 'opencode']);
@@ -142,7 +142,9 @@ export async function runEvals(dir: string, opts: RunOptions) {
     const warnedNoModelSupport = new Set<string>();
 
     // Run each task
+    let taskIndex = 0;
     for (const taskDef of tasksToRun) {
+        taskIndex++;
         const resolved = await resolveTask(taskDef, config.defaults, dir);
         const trials = opts.trials ?? resolved.trials;
         const parallel = opts.parallel ?? 1;
@@ -263,7 +265,7 @@ export async function runEvals(dir: string, opts: RunOptions) {
             // Normal eval mode
             const agent = createAgent(agentName, agentConfig);
 
-            header(resolved.name);
+            header(`${resolved.name}  ${fmt.dim(`(${taskIndex}/${tasksToRun.length})`)}`);
             console.log(`    ${fmt.dim('agent')} ${agentName}${modelName ? `  ${fmt.dim('model')} ${modelName}` : ''}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
             console.log();
 
@@ -287,6 +289,12 @@ export async function runEvals(dir: string, opts: RunOptions) {
                 console.error(`\n  ${fmt.fail('error')}  evaluation failed: ${err}\n`);
                 allPassed = false;
             }
+        }
+
+        // How far through the selected tasks we are. Pointless for a single
+        // task, and the run is otherwise silent about it until the very end.
+        if (tasksToRun.length > 1) {
+            progress(taskIndex, tasksToRun.length);
         }
 
         // Cleanup temp dir

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -25,9 +25,15 @@ export const fmt = {
     fail: (s: string) => `${bold}${red}${s}${reset}`,
 };
 
+/** Printable width of a string, ignoring any ANSI escape sequences in it. */
+function visibleLength(s: string): number {
+    // eslint-disable-next-line no-control-regex
+    return s.replace(/\x1b\[[0-9;]*m/g, '').length;
+}
+
 /** Print a section header with a rule line */
 export function header(title: string, width: number = 60) {
-    const rule = '─'.repeat(Math.max(0, width - title.length - 3));
+    const rule = '─'.repeat(Math.max(0, width - visibleLength(title) - 3));
     console.log(`\n${fmt.bold(`── ${title} `)}${fmt.dim(rule)}`);
 }
 
@@ -52,6 +58,25 @@ export function trialRow(trialId: number, total: number, reward: number, duratio
     }).join('  ');
 
     console.log(`${pad}  ${fmt.dim(trialLabel)} ${status}  ${fmt.bold(rewardStr)}  ${fmt.dim(duration.padEnd(7))} ${fmt.dim(commands + ' cmds')}  ${graderStr}`);
+}
+
+/**
+ * Render a fixed-width progress bar: `▓▓▓▓▓░░░░░  10/20  50%`.
+ *
+ * Segments are fixed rather than proportional to the terminal so the bar reads
+ * the same in a narrow pane, in CI logs and in a pasted transcript.
+ */
+export function progressBar(done: number, total: number, segments: number = 10): string {
+    const ratio = total > 0 ? Math.min(1, Math.max(0, done / total)) : 0;
+    const filled = Math.round(ratio * segments);
+    const bar = '▓'.repeat(filled) + '░'.repeat(Math.max(0, segments - filled));
+    const pct = `${Math.round(ratio * 100)}%`;
+    return `${bar}  ${done}/${total}  ${pct}`;
+}
+
+/** Print the progress line shown after each task completes */
+export function progress(done: number, total: number) {
+    console.log(`\n  ${fmt.dim('progress')}    ${progressBar(done, total)}`);
 }
 
 /** Print the results summary block */

--- a/tests/utils.progress.test.ts
+++ b/tests/utils.progress.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fmt, header, progressBar } from '../src/utils/cli';
+
+describe('progressBar', () => {
+  it('renders the example from the docs', () => {
+    expect(progressBar(10, 20)).toBe('▓▓▓▓▓░░░░░  10/20  50%');
+  });
+
+  it('is empty at the start and full at the end', () => {
+    expect(progressBar(0, 22)).toBe('░░░░░░░░░░  0/22  0%');
+    expect(progressBar(22, 22)).toBe('▓▓▓▓▓▓▓▓▓▓  22/22  100%');
+  });
+
+  it('always renders exactly `segments` cells', () => {
+    for (let done = 0; done <= 7; done++) {
+      const bar = progressBar(done, 7).split('  ')[0];
+      expect(bar).toHaveLength(10);
+    }
+  });
+
+  it('honours a custom segment count', () => {
+    expect(progressBar(1, 4, 4)).toBe('▓░░░  1/4  25%');
+  });
+
+  it('does not divide by zero when there are no tasks', () => {
+    expect(progressBar(0, 0)).toBe('░░░░░░░░░░  0/0  0%');
+  });
+
+  it('clamps rather than overflowing when done exceeds total', () => {
+    expect(progressBar(5, 3)).toBe('▓▓▓▓▓▓▓▓▓▓  5/3  100%');
+  });
+});
+
+describe('header', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  /** The rule line the header prints, with all styling stripped. */
+  const ruleFor = (title: string) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    header(title);
+    const line = String(logSpy.mock.calls[0][0]).replace(/\x1b\[[0-9;]*m/g, '');
+    return line.trim();
+  };
+
+  it('rules to the same width whether or not the title is styled', () => {
+    const plain = ruleFor('alpha  (1/3)');
+    const styled = ruleFor(`alpha  ${fmt.dim('(1/3)')}`);
+    expect(styled).toBe(plain);
+  });
+
+  it('rules to a constant width regardless of title length', () => {
+    expect(ruleFor('alpha').length).toBe(ruleFor('a-much-longer-task-name').length);
+  });
+});


### PR DESCRIPTION
A run over 20+ tasks prints a Results block per task and nothing about the run as a whole until it ends, so there is no way to tell from the terminal whether you are two minutes or twenty from done.

Each task header now carries its index, and a fixed 10-segment bar follows every completed task:

```
── palette-30cb6365  (11/22) ──────────────────────────
    agent claude  provider local  trials 1
    1/1    PASS  1.00  42.1s  3 cmds

── Results ────────────────────────────────────────────
    Pass Rate    100.0%
    pass@1       100.0%
    pass^1       100.0%

  progress    ▓▓▓▓▓░░░░░  11/22  50%
```

Fixed segment count rather than terminal-width, so it reads the same in a narrow pane, in CI logs and in a pasted transcript. Skipped for single-task runs, where `1/1 100%` says nothing.

The index counts through the *selected* tasks, so it agrees with the `selected N of M tasks` line when `--eval` / `--filter` narrows the run.

## Also in here

`header()` sized its rule line from `title.length`, which counts ANSI escape bytes. Passing a styled title — the dimmed index above — made every task rule come out 8 columns short of the `── Results ──` rule below it. It now measures printable width, so all headers rule to the same column.

## Notes

- Rebased onto `main` after #32 and #34; the one conflict was the agent line, which now shows both the task index and `--model`.
- 252 tests pass. 8 new: 6 cover the bar itself (the documented example, both ends, exact cell count at every step, a custom segment count, zero tasks, and `done > total` clamping), 2 cover the header ruling to a constant width with and without styling in the title.
- `progressBar()` is exported separately from the printing helper so it stays a pure, testable function.
- Happy to change the characters if `▓░` is not to taste, or to move the line elsewhere in the block.

