### PR TITLE
feat(cli): always show model in the run header for model-aware agents

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -21,6 +21,21 @@ import { fmt, header, kv, progress, resultsSummary, validationResult } from '../
 /** Agents that accept a model on the command line. */
 const MODEL_AWARE_AGENTS = new Set(['gemini', 'claude', 'codex', 'opencode']);
 
+/**
+ * What to print for --model in the run header.
+ *
+ * An agent with no model concept (acp, command) gets nothing — there is
+ * nothing true to say. A model-aware agent always gets a line: the pinned
+ * value, or "default" when none was given. Without this, running claude with
+ * no --model silently answers with whatever the account default is, which is
+ * exactly the case that most needs to be visible — it's the one nothing else
+ * reports, and it can change under you.
+ */
+export function modelLabel(agentName: string, requestedModel: string | undefined): string | undefined {
+    if (!MODEL_AWARE_AGENTS.has(agentName)) return undefined;
+    return requestedModel || 'default';
+}
+
 interface RunOptions {
     eval?: string;       // run specific eval(s) by name (comma-separated)
     filters?: TaskFilter[];   // --filter / --not-filter over task metadata
@@ -184,8 +199,9 @@ export async function runEvals(dir: string, opts: RunOptions) {
         const providerName = opts.provider || resolved.provider;
         // CLI flag > task-level override > defaults; undefined means the agent CLI decides
         const requestedModel = opts.model || resolved.model;
-        // Only reported when it is actually used — printing a model the agent
-        // ignores would make a run look like something it was not.
+        // Only PASSED to the agent CLI when actually given — forwarding a model
+        // the agent ignores would make a run look like something it was not.
+        // The header line shows more than this: see modelLabel().
         const modelName = MODEL_AWARE_AGENTS.has(agentName) ? requestedModel : undefined;
         if (requestedModel && !modelName && !warnedNoModelSupport.has(agentName)) {
             warnedNoModelSupport.add(agentName);
@@ -266,7 +282,8 @@ export async function runEvals(dir: string, opts: RunOptions) {
             const agent = createAgent(agentName, agentConfig);
 
             header(`${resolved.name}  ${fmt.dim(`(${taskIndex}/${tasksToRun.length})`)}`);
-            console.log(`    ${fmt.dim('agent')} ${agentName}${modelName ? `  ${fmt.dim('model')} ${modelName}` : ''}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
+            const label = modelLabel(agentName, requestedModel);
+            console.log(`    ${fmt.dim('agent')} ${agentName}${label ? `  ${fmt.dim('model')} ${label}` : ''}  ${fmt.dim('provider')} ${providerName}  ${fmt.dim('trials')} ${trials}${parallel > 1 ? `  ${fmt.dim('parallel')} ${parallel}` : ''}`);
             console.log();
 
             try {

--- a/tests/commands.run.test.ts
+++ b/tests/commands.run.test.ts
@@ -14,7 +14,7 @@ vi.mock('fs-extra', () => ({
 
 import * as fs from 'fs-extra';
 import { ResolvedTask } from '../src/core/config.types';
-import { prepareTempTaskDir } from '../src/commands/run';
+import { prepareTempTaskDir, modelLabel } from '../src/commands/run';
 
 // TaskConfig type for testing (not exported from types)
 interface TaskConfig {
@@ -285,5 +285,23 @@ describe('prepareTempTaskDir', () => {
     const dockerfileCall = mockWriteFile.mock.calls.find(c => c[0] === path.join('/tmp/task', 'environment', 'Dockerfile'));
     expect(dockerfileCall).toBeDefined();
     expect(dockerfileCall![1]).toContain('COPY main.ts app/main.ts');
+  });
+});
+
+describe('modelLabel', () => {
+  it('shows the pinned model for a model-aware agent', () => {
+    expect(modelLabel('claude', 'opus')).toBe('opus');
+  });
+
+  it('falls back to "default" when a model-aware agent got no --model', () => {
+    expect(modelLabel('claude', undefined)).toBe('default');
+    expect(modelLabel('gemini', undefined)).toBe('default');
+    expect(modelLabel('codex', undefined)).toBe('default');
+    expect(modelLabel('opencode', undefined)).toBe('default');
+  });
+
+  it('shows nothing for an agent with no model concept, even if one was requested', () => {
+    expect(modelLabel('command', 'opus')).toBeUndefined();
+    expect(modelLabel('acp', undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Without `--model`, the run header silently dropped the model field entirely, so a run with `claude` (or `gemini`/`codex`/`opencode`) gave no indication it was answering with whatever the agent CLI's account default happened to be — the exact case `agents/claude.ts` already calls out as "invisible in the results and can change under you".
- A model-aware agent now always prints a `model` line: the pinned value when `--model`/`model:` was given, or `default` when it wasn't. An agent with no model concept (`acp`, `command`) still prints nothing — there's nothing true to say there.
- Extracted the decision into a small pure `modelLabel(agentName, requestedModel)` helper (exported alongside `prepareTempTaskDir`) so it's unit-testable on its own.

## Test plan
- [x] `npx vitest run` — 255/255 passing (3 new cases for `modelLabel`)
- [x] `npx tsc -p tsconfig.build.json --noEmit` — no new type errors (the one pre-existing `docker.ts` error is present on a clean `main` checkout too, unrelated to this change)
- [x] Manually checked the built header string for `claude`/no-model, `claude`/`opus`, `gemini`/no-model, and `command`/no-model — matches the intended output